### PR TITLE
export PostgresTextEncoder

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -4,4 +4,5 @@ export 'src/connection.dart';
 export 'src/execution_context.dart';
 export 'src/models.dart';
 export 'src/substituter.dart';
+export 'src/text_codec.dart';
 export 'src/types.dart';


### PR DESCRIPTION
Can we do this please? I need to use the `.convert()` method directly in my project.