### PR TITLE
src/query.dart exported

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -5,3 +5,4 @@ export 'src/execution_context.dart';
 export 'src/models.dart';
 export 'src/substituter.dart';
 export 'src/types.dart';
+export 'src/query.dart';


### PR DESCRIPTION
I need to access the class ColumnDescription as FieldDescription to grant access to typeID property of this class.
The class FieldDescription is writed in file "query.dart" thats not exported.

With this information, i can automate proccess im my project.

