### PR TITLE
Decoder for numeric / decimal SQL Data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased 
+
+- Decoder for type `numeric` / `decimal`, [#7](https://github.com/isoos/postgresql-dart/pull/7).
+
 ## 2.3.2
 
 - Expose `ColumnDescription.typeId`.

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -329,6 +329,9 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
         return DateTime.utc(2000)
             .add(Duration(microseconds: buffer.getInt64(0)));
 
+      case PostgreSQLDataType.numeric:
+        return _decodeNumeric(buffer);
+
       case PostgreSQLDataType.date:
         return DateTime.utc(2000).add(Duration(days: buffer.getInt32(0)));
 
@@ -425,6 +428,7 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
     return decoded;
   }
 
+  /// See: https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat
   static final Map<int, PostgreSQLDataType> typeMap = {
     16: PostgreSQLDataType.boolean,
     17: PostgreSQLDataType.byteArray,
@@ -444,8 +448,33 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
     1082: PostgreSQLDataType.date,
     1114: PostgreSQLDataType.timestampWithoutTimezone,
     1184: PostgreSQLDataType.timestampWithTimezone,
+    1700: PostgreSQLDataType.numeric,
     2950: PostgreSQLDataType.uuid,
     3802: PostgreSQLDataType.jsonb,
     3807: PostgreSQLDataType.jsonbArray,
   };
+
+  /// Decode numeric / decimal to String without loosing precision.
+  /// See encoding: https://github.com/postgres/postgres/blob/0e39a608ed5545cc6b9d538ac937c3c1ee8cdc36/src/backend/utils/adt/numeric.c#L305
+  /// See implementation: https://github.com/charmander/pg-numeric/blob/0c310eeb11dc680dffb7747821e61d542831108b/index.js#L13
+  static String _decodeNumeric(ByteData buffer) {
+    final nDigits = buffer.getInt16(0); // non-zero digits, data buffer length = 2 * nDigits
+    var weight = buffer.getInt16(2); // weight of first digit
+    final signByte = buffer.getInt16(4); // NUMERIC_POS, NEG, NAN, PINF, or NINF
+    final dScale = buffer.getInt16(6); // display scale
+    if (signByte == 0xc000) return 'NaN';
+    final sign = signByte == 0x4000 ? '-' : '';
+    var intPart = '';
+    var fractPart = '';
+    final prependBytes = 8;
+    for (var i = prependBytes; i < (nDigits * 2 + prependBytes); i += 2) {
+      if (weight >= 0) {
+        intPart += buffer.getUint16(i).toString().padLeft(4, '0');
+      } else {
+        fractPart += buffer.getUint16(i).toString().padLeft(4, '0');
+      }
+      weight--;
+    }
+    return '$sign${intPart.replaceAll(RegExp(r'^0+'), '')}.${fractPart.padRight(dScale, '0').substring(0, dScale)}';
+  }
 }

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -321,6 +321,7 @@ class PostgreSQLFormatIdentifier {
     'date': PostgreSQLDataType.date,
     'timestamp': PostgreSQLDataType.timestampWithoutTimezone,
     'timestamptz': PostgreSQLDataType.timestampWithTimezone,
+    'numeric': PostgreSQLDataType.numeric,
     'jsonb': PostgreSQLDataType.jsonb,
     'bytea': PostgreSQLDataType.byteArray,
     'name': PostgreSQLDataType.name,

--- a/lib/src/substituter.dart
+++ b/lib/src/substituter.dart
@@ -37,6 +37,8 @@ class PostgreSQLFormat {
         return 'timestamp';
       case PostgreSQLDataType.timestampWithTimezone:
         return 'timestamptz';
+      case PostgreSQLDataType.numeric:
+        return 'numeric';
       case PostgreSQLDataType.date:
         return 'date';
       case PostgreSQLDataType.jsonb:

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -42,6 +42,9 @@ enum PostgreSQLDataType {
   /// Must be a [DateTime] (microsecond date and time precision)
   timestampWithTimezone,
 
+  /// Must be a [List<int>]
+  numeric,
+
   /// Must be a [DateTime] (contains year, month and day only)
   date,
 

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -1,4 +1,7 @@
+import 'dart:typed_data';
+
 import 'package:postgres/postgres.dart';
+import 'package:postgres/src/binary_codec.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -166,5 +169,21 @@ void main() {
     expect(results, [
       [null]
     ]);
+  });
+
+  test('Decode Numeric to String', () {
+    // -123400000.2
+    final binary1 = [0, 4, 0, 2, 64, 0, 0, 5, 0, 1, 9, 36, 0, 0, 7, 208];
+
+    // -123400001.01234
+    final binary2 = [0, 5, 0, 2, 64, 0, 0, 5, 0, 1, 9, 36, 0, 1, 0, 0, 7, 208];
+
+    final decoder = PostgresBinaryDecoder(1700);
+    final uint8List1 = Uint8List.fromList(binary1);
+    final uint8List2 = Uint8List.fromList(binary2);
+    final res1 = decoder.convert(uint8List1);
+    final res2 = decoder.convert(uint8List2);
+    expect(res1, '-123400000.20000');
+    expect(res2, '-123400001.00002');
   });
 }


### PR DESCRIPTION
Closes https://github.com/stablekernel/postgresql-dart/issues/50,
closes https://github.com/stablekernel/postgresql-dart/issues/108,
closes https://github.com/stablekernel/postgresql-dart/issues/112,
closes https://github.com/stablekernel/postgresql-dart/issues/162,
Contributes to https://github.com/stablekernel/postgresql-dart/issues/164

Encoder may follows, if I've time.
At least I wanted to give a decoding option to the users who need it.

I decided to use String as exact representation of BigDecimal. An alternative would be to use [decimal package](https://pub.dev/packages/decimal) , but I don't know if its a good idea, to use third party package as datatype. If wanted the users can use the package and convert the string themselves with the [`Decimal.parse`](https://pub.dev/packages/decimal/example) method, or use `double.parse()`, if precision is not that important.

I think [BigInt](https://api.dart.dev/stable/2.10.5/dart-core/BigInt-class.html) isn't an option, as need to save the fractional digits and therefore would again need a new wrapper class.

I also implemented a less precise `numericToDouble` method, but I think we should stick to the String representation:

```
/// Decode numeric / decimal to double which may has loss in precision.
double decodeNumericToDouble(List<int> bytes) {
  final uint8List = Uint8List.fromList(bytes);
  final buffer = ByteData.sublistView(uint8List);
  final nDigits = buffer.getInt16(0); // non-zero digits, data buffer length = 2 * nDigits
  var weight = buffer.getInt16(2); // weight of first digit
  final signByte = buffer.getInt16(4); // NUMERIC_POS, NEG, NAN, PINF, or NINF
  final dScale = buffer.getInt16(6); // display scale
  if (signByte == 0xc000) return double.nan;
  final sign = signByte == 0x4000 ? -1 : 1;
  final prependBytes = 8;
  var decimal = 0.0;
  for (var i = prependBytes; i < (nDigits * 2 + prependBytes); i += 2) {
    decimal += buffer.getUint16(i) * pow(10000, weight);
    weight--;
  }
  return decimal * sign;
}
```