### PR TITLE
update allowReuse nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.1+1
+
+- Fix error when passing `allowReuse: null` into `query()` [#8](https://github.com/isoos/postgresql-dart/pull/8)
+
 ## 2.4.1
 
 - Support for type `interval`, [#10](https://github.com/isoos/postgresql-dart/pull/10).

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -416,13 +416,13 @@ abstract class _PostgreSQLExecutionContextMixin
   Future<PostgreSQLResult> query(
     String fmtString, {
     Map<String, dynamic>? substitutionValues,
-    bool? allowReuse = true,
+    bool? allowReuse,
     int? timeoutInSeconds,
   }) =>
       _query(
         fmtString,
         substitutionValues: substitutionValues,
-        allowReuse: allowReuse!,
+        allowReuse: allowReuse ?? true,
         timeoutInSeconds: timeoutInSeconds,
       );
 
@@ -467,12 +467,12 @@ abstract class _PostgreSQLExecutionContextMixin
   Future<List<Map<String, Map<String, dynamic>>>> mappedResultsQuery(
       String fmtString,
       {Map<String, dynamic>? substitutionValues = const {},
-      bool? allowReuse = false,
+      bool? allowReuse,
       int? timeoutInSeconds}) async {
     final rs = await query(
       fmtString,
       substitutionValues: substitutionValues,
-      allowReuse: allowReuse!,
+      allowReuse: allowReuse ?? false,
       timeoutInSeconds: timeoutInSeconds,
     );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 2.4.1
+version: 2.4.1+1
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:


### PR DESCRIPTION
imho allowReuse should either be a non-nullable value or the default value should be used as a fallback when accessed.

otherwise callers can pass in `allowReuse: null` and cause a crash. 😳