### PR TITLE
Binary encoder for numeric datatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased 
 
-- Decoder for type `numeric` / `decimal`, [#7](https://github.com/isoos/postgresql-dart/pull/7).
+- Support for type `numeric` / `decimal` ([#7](https://github.com/isoos/postgresql-dart/pull/7), [#9](https://github.com/isoos/postgresql-dart/pull/9)).
 
 ## 2.3.2
 

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -177,18 +177,21 @@ void main() {
   });
 
   test('Decode Numeric to String', () {
-    // -123400000.2
-    final binary1 = [0, 4, 0, 2, 64, 0, 0, 5, 0, 1, 9, 36, 0, 0, 7, 208];
-
-    // -123400001.01234
-    final binary2 = [0, 5, 0, 2, 64, 0, 0, 5, 0, 1, 9, 36, 0, 1, 0, 0, 7, 208];
+    final binaries = {
+      '-123400000.20000': [0, 4, 0, 2, 64, 0, 0, 5, 0, 1, 9, 36, 0, 0, 7, 208],
+      '-123400001.00002': [0, 5, 0, 2, 64, 0, 0, 5, 0, 1, 9, 36, 0, 1, 0, 0, 7, 208],
+      '0.00001': [0, 1, 255, 254, 0, 0, 0, 5, 3, 232],
+      '10000.000000000': [0, 1, 0, 1, 0, 0, 0, 9, 0, 1],
+      'NaN': [0, 0, 0, 0, 192, 0, 0, 0],
+      '0': [0, 0, 0, 0, 0, 0, 0, 0], // 0 or 0.
+      '0.0': [0, 0, 0, 0, 0, 0, 0, 1], // .0 or 0.0
+    };
 
     final decoder = PostgresBinaryDecoder(1700);
-    final uint8List1 = Uint8List.fromList(binary1);
-    final uint8List2 = Uint8List.fromList(binary2);
-    final res1 = decoder.convert(uint8List1);
-    final res2 = decoder.convert(uint8List2);
-    expect(res1, '-123400000.20000');
-    expect(res2, '-123400001.00002');
+    binaries.forEach((key, value) {
+      final uint8List = Uint8List.fromList(value);
+      final res = decoder.convert(uint8List);
+      expect(res, key);
+    });
   });
 }

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -14,31 +14,33 @@ void main() {
     await connection.execute('''
         CREATE TEMPORARY TABLE t (
           i int, s serial, bi bigint, bs bigserial, bl boolean, si smallint, 
-          t text, f real, d double precision, dt date, ts timestamp, tsz timestamptz, j jsonb, ba bytea,
+          t text, f real, d double precision, dt date, ts timestamp, tsz timestamptz, n numeric, j jsonb, ba bytea,
           u uuid, v varchar, p point, jj json, ia _int4, ta _text, da _float8, ja _jsonb)
     ''');
 
     await connection.execute(
-        'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz, j, ba, u, v, p, jj, ia, ta, da, ja) '
+        'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz, n, j, ba, u, v, p, jj, ia, ta, da, ja) '
         'VALUES (-2147483648, -9223372036854775808, TRUE, -32768, '
         "'string', 10.0, 10.0, '1983-11-06', "
         "'1983-11-06 06:00:00.000000', '1983-11-06 06:00:00.000000', "
+        "'-1234567890.0987654321', "
         "'{\"key\":\"value\"}', E'\\\\000', '00000000-0000-0000-0000-000000000000', "
         "'abcdef', '(0.01, 12.34)', '{\"key\": \"value\"}', '{}', '{}', '{}', '{}')");
     await connection.execute(
-        'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz, j, ba, u, v, p, jj, ia, ta, da, ja) '
+        'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz, n, j, ba, u, v, p, jj, ia, ta, da, ja) '
         'VALUES (2147483647, 9223372036854775807, FALSE, 32767, '
         "'a significantly longer string to the point where i doubt this actually matters', "
         "10.25, 10.125, '2183-11-06', '2183-11-06 00:00:00.111111', "
         "'2183-11-06 00:00:00.999999', "
+        "'1000000000000000000000000000.0000000000000000000000000001', "
         "'[{\"key\":1}]', E'\\\\377', 'FFFFFFFF-ffff-ffff-ffff-ffffffffffff', "
         "'01234', '(0.2, 100)', '{}', '{-123, 999}', '{\"a\", \"lorem ipsum\", \"\"}', "
         "'{1, 2, 4.5, 1234.5}', '{1, \"\\\"test\\\"\", \"{\\\"a\\\": \\\"b\\\"}\"}')");
 
     await connection.execute(
-        'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz, j, ba, u, v, p, jj, ia, ta, da, ja) '
+        'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz, n, j, ba, u, v, p, jj, ia, ta, da, ja) '
         'VALUES (null, null, null, null, null, null, null, null, null, null, null, null, null, '
-        'null, null, null, null, null, null, null )');
+        'null, null, null, null, null, null, null, null )');
   });
   tearDown(() async {
     await connection.close();
@@ -66,16 +68,17 @@ void main() {
     expect(row1[9], equals(DateTime.utc(1983, 11, 6)));
     expect(row1[10], equals(DateTime.utc(1983, 11, 6, 6)));
     expect(row1[11], equals(DateTime.utc(1983, 11, 6, 6)));
-    expect(row1[12], equals({'key': 'value'}));
-    expect(row1[13], equals([0]));
-    expect(row1[14], equals('00000000-0000-0000-0000-000000000000'));
-    expect(row1[15], equals('abcdef'));
-    expect(row1[16], equals(PgPoint(0.01, 12.34)));
-    expect(row1[17], equals({'key': 'value'}));
-    expect(row1[18], equals(<int>[]));
-    expect(row1[19], equals(<String>[]));
-    expect(row1[20], equals(<double>[]));
-    expect(row1[21], equals([]));
+    expect(row1[12], equals('-1234567890.0987654321'));
+    expect(row1[13], equals({'key': 'value'}));
+    expect(row1[14], equals([0]));
+    expect(row1[15], equals('00000000-0000-0000-0000-000000000000'));
+    expect(row1[16], equals('abcdef'));
+    expect(row1[17], equals(PgPoint(0.01, 12.34)));
+    expect(row1[18], equals({'key': 'value'}));
+    expect(row1[19], equals(<int>[]));
+    expect(row1[20], equals(<String>[]));
+    expect(row1[21], equals(<double>[]));
+    expect(row1[22], equals([]));
 
     // upper bound row
     expect(row2[0], equals(2147483647));
@@ -95,21 +98,22 @@ void main() {
     expect(row2[9], equals(DateTime.utc(2183, 11, 6)));
     expect(row2[10], equals(DateTime.utc(2183, 11, 6, 0, 0, 0, 111, 111)));
     expect(row2[11], equals(DateTime.utc(2183, 11, 6, 0, 0, 0, 999, 999)));
+    expect(row2[12], equals('1000000000000000000000000000.0000000000000000000000000001'));
     expect(
-        row2[12],
+        row2[13],
         equals([
           {'key': 1}
         ]));
-    expect(row2[13], equals([255]));
-    expect(row2[14], equals('ffffffff-ffff-ffff-ffff-ffffffffffff'));
-    expect(row2[15], equals('01234'));
-    expect(row2[16], equals(PgPoint(0.2, 100)));
-    expect(row2[17], equals({}));
-    expect(row2[18], equals(<int>[-123, 999]));
-    expect(row2[19], equals(<String>['a', 'lorem ipsum', '']));
-    expect(row2[20], equals(<double>[1, 2, 4.5, 1234.5]));
+    expect(row2[14], equals([255]));
+    expect(row2[15], equals('ffffffff-ffff-ffff-ffff-ffffffffffff'));
+    expect(row2[16], equals('01234'));
+    expect(row2[17], equals(PgPoint(0.2, 100)));
+    expect(row2[18], equals({}));
+    expect(row2[19], equals(<int>[-123, 999]));
+    expect(row2[20], equals(<String>['a', 'lorem ipsum', '']));
+    expect(row2[21], equals(<double>[1, 2, 4.5, 1234.5]));
     expect(
-        row2[21],
+        row2[22],
         equals([
           1,
           'test',
@@ -139,6 +143,7 @@ void main() {
     expect(row3[19], isNull);
     expect(row3[20], isNull);
     expect(row3[21], isNull);
+    expect(row3[22], isNull);
   });
 
   test('Fetch/insert empty string', () async {


### PR DESCRIPTION
- Closes https://github.com/stablekernel/postgresql-dart/issues/164
- Binary Encoder for numeric / decimal SQL Data Type
- Fix decoding numeric values with trailing or leading zeros
- More tests

It seems that the implementation is quite heavy, but when I looked into other repositories, they also have a bulk of code:
- BigDecimal Implementation of [a14n](https://github.com/a14n/dart-rational/blob/a93551360c2882cb5a96118d0c4653847b30ad8f/lib/rational.dart#L62), which cannot be applied 1:1, as Postgres Numeric uses another binary format than BigDecimal.
- BigDecimal Implementation of [Java](https://github.com/frohoff/jdk8u-dev-jdk/blob/da0da73ab82ed714dc5be94acd2f0d00fbdfe2e9/src/share/classes/java/math/BigDecimal.java#L409): Same applies to Java.
- You may find another lib which implements the binary format, then let me know (e.g. [node-postgres doesn't](https://github.com/brianc/node-postgres/blob/947ccee346f0d598e135548e1e4936a9a008fc6f/packages/pg/test/integration/client/type-coercion-tests.js#L135)). 
