### PR TITLE
fix sending json with execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.1+2
+
+- Fix error when sending json data with `execute()` [#11](https://github.com/isoos/postgresql-dart/pull/11)
+
 ## 2.4.1+1
 
 - Fix error when passing `allowReuse: null` into `query()` [#8](https://github.com/isoos/postgresql-dart/pull/8)

--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -29,7 +29,7 @@ class PostgresTextEncoder {
     }
 
     if (value is Map) {
-      return _encodeJSON(value);
+      return _encodeJSON(value, escapeStrings);
     }
 
     if (value is PgPoint) {
@@ -152,7 +152,7 @@ class PostgresTextEncoder {
     return "'$string'";
   }
 
-  String _encodeJSON(dynamic value) {
+  String _encodeJSON(dynamic value, bool escapeStrings) {
     if (value == null) {
       return 'null';
     }
@@ -161,7 +161,7 @@ class PostgresTextEncoder {
       return "'${json.encode(value)}'";
     }
 
-    return json.encode(value);
+    return _encodeString(json.encode(value), escapeStrings);
   }
 
   String _encodePoint(PgPoint value) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 2.4.1+1
+version: 2.4.1+2
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -546,9 +546,12 @@ void main() {
     });
 
     test('Encode JSONB', () {
-      expect(encoder.convert({'a': 'b'}), '{"a":"b"}');
-      expect(encoder.convert({'a': true}), '{"a":true}');
-      expect(encoder.convert({'b': false}), '{"b":false}');
+      expect(encoder.convert({'a': 'b'}, escapeStrings: false), '{"a":"b"}');
+      expect(encoder.convert({'a': true}, escapeStrings: false), '{"a":true}');
+      expect(
+          encoder.convert({'b': false}, escapeStrings: false), '{"b":false}');
+      expect(encoder.convert({'a': true}), '\'{"a":true}\'');
+      expect(encoder.convert({'b': false}), '\'{"b":false}\'');
     });
 
     test('Attempt to infer unknown type throws exception', () {

--- a/test/json_test.dart
+++ b/test/json_test.dart
@@ -103,6 +103,20 @@ void main() {
         ]
       ]);
     });
+    test('Can store JSON map with execute', () async {
+      final result = await connection.execute(
+          'INSERT INTO t (j) VALUES (@a:jsonb) RETURNING j',
+          substitutionValues: {
+            'a': {'a': 4}
+          });
+      expect(result, 1);
+      final resultQuery = await connection.query('SELECT j FROM t');
+      expect(resultQuery, [
+        [
+          {'a': 4}
+        ]
+      ]);
+    });
 
     test('Can store JSON list', () async {
       var result = await connection


### PR DESCRIPTION
I tried to bind a json value but couldn't get it to work. After further inspection it looks like json only works for `query` but not for `execute`.

Because of some reason `query` uses native binding, while `execute` uses `sendSimple`

https://github.com/isoos/postgresql-dart/blob/1d74c21fa160859cbb1889f945c22f39f168d4d1/lib/src/connection_fsm.dart#L198-L201

I don't understand at all why there is a difference? Why use `sendSimple` for `execute`?

This PR is only to reproduce the bug. Please advise how to fix it? Does it make sense to try to support json in `sendSimple` or should everything use `sendExtended`?

the error message is:

```
PostgreSQLSeverity.error 42601: syntax error at or near "{" 
```

(I assume the CI should show that as well)
