### PR TITLE
Include original stacktrace when query fails

### DIFF
--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -370,7 +370,7 @@ class _OidCache {
         .toSet()
         .where((oid) => oid > 0 && !_tableOIDNameMap.containsKey(oid))
         .toList()
-          ..sort();
+      ..sort();
 
     if (unresolvedTableOIDs.isNotEmpty) {
       await _resolveTableOIDs(c, unresolvedTableOIDs);
@@ -441,7 +441,12 @@ abstract class _PostgreSQLExecutionContextMixin
     }
 
     final query = Query<List<List<dynamic>>>(
-        fmtString, substitutionValues, _connection, _transaction);
+      fmtString,
+      substitutionValues,
+      _connection,
+      _transaction,
+      StackTrace.current,
+    );
     if (allowReuse) {
       query.statementIdentifier = _connection._cache.identifierForQuery(query);
     }
@@ -489,8 +494,8 @@ abstract class _PostgreSQLExecutionContextMixin
           'Attempting to execute query, but connection is not open.');
     }
 
-    final query = Query<void>(
-        fmtString, substitutionValues, _connection, _transaction,
+    final query = Query<void>(fmtString, substitutionValues, _connection,
+        _transaction, StackTrace.current,
         onlyReturnAffectedRowCount: true);
 
     final result = await _enqueue(query, timeoutInSeconds: timeoutInSeconds);

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -18,7 +18,8 @@ class Query<T> {
     this.statement,
     this.substitutionValues,
     this.connection,
-    this.transaction, {
+    this.transaction,
+    this.queryStackTrace, {
     this.onlyReturnAffectedRowCount = false,
   });
 
@@ -42,6 +43,8 @@ class Query<T> {
   List<FieldDescription>? _fieldDescriptions;
 
   List<FieldDescription>? get fieldDescriptions => _fieldDescriptions;
+
+  final StackTrace queryStackTrace;
 
   set fieldDescriptions(List<FieldDescription>? fds) {
     _fieldDescriptions = fds;
@@ -166,7 +169,7 @@ class Query<T> {
       return;
     }
 
-    _onComplete.completeError(error, stackTrace);
+    _onComplete.completeError(error, stackTrace ?? queryStackTrace);
   }
 
   @override

--- a/lib/src/transaction_proxy.dart
+++ b/lib/src/transaction_proxy.dart
@@ -8,7 +8,7 @@ class _TransactionProxy extends Object
     implements PostgreSQLExecutionContext {
   _TransactionProxy(
       this._connection, this.executionBlock, this.commitTimeoutInSeconds) {
-    _beginQuery = Query<int>('BEGIN', {}, _connection, this,
+    _beginQuery = Query<int>('BEGIN', {}, _connection, this, StackTrace.current,
         onlyReturnAffectedRowCount: true);
 
     _beginQuery.future
@@ -89,7 +89,8 @@ class _TransactionProxy extends Object
         'that prevented this query from executing.');
     _queue.cancel(err);
 
-    final rollback = Query<int>('ROLLBACK', {}, _connection, _transaction,
+    final rollback = Query<int>(
+        'ROLLBACK', {}, _connection, _transaction, StackTrace.current,
         onlyReturnAffectedRowCount: true);
     _queue.addEvenIfCancelled(rollback);
 

--- a/test/error_handling_test.dart
+++ b/test/error_handling_test.dart
@@ -15,8 +15,8 @@ void main() {
       await conn.query('SELECT hello');
       fail('Should not reach');
     } catch (e, st) {
-      // TODO: This expectation fails
-      //expect(st.toString(), isNotEmpty);
+      expect(st.toString(), isNotEmpty);
+      expect(st.toString(), contains('postgresql-dart/test/error_handling_test.dart'));
     }
   });
 }

--- a/test/error_handling_test.dart
+++ b/test/error_handling_test.dart
@@ -12,12 +12,25 @@ void main() {
     await conn.open();
     addTearDown(() async => conn.close());
 
-    // Root connection
+    // Root connection query
     try {
       await conn.query('SELECT hello');
       fail('Should not reach');
     } catch (e, st) {
       expect(e.toString(), contains('column "hello" does not exist'));
+      expect(
+        st.toString(),
+        contains('postgresql-dart/test/error_handling_test.dart'),
+      );
+    }
+
+    // Root connection execute
+    try {
+      await conn.execute('DELETE FROM hello');
+      fail('Should not reach');
+    } catch (e, st) {
+      print(e);
+      expect(e.toString(), contains('relation "hello" does not exist'));
       expect(
         st.toString(),
         contains('postgresql-dart/test/error_handling_test.dart'),


### PR DESCRIPTION
@isoos Hello! I've come up with a solution for the stacktrace issue.
Since a queue is used to resolve the queries, we cannot simply include the `StackTrace` at the location of `Completer.completeError`, so when creating the `Query` object, the `StackTrace` at that time is attached. That way, when the error happens, we can use that one instead.
I don't know if there is a better way to do this kind of `StackTrace` handling, but with this (maybe naive) solution we get the exact line that caused the error.