### PR TITLE
Clear text conn type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.3
+- Add authenticator for passwords required as ClearText. Fixes connections issues with Azure Database for PostgreSQL.
+- Added a new boolean parameter in connection as 'allowClearTextPassword' to activate / deactivate the feature.
+
 ## 2.4.2
 
 - Include original stacktrace when query fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## 2.4.3
-- Add authenticator for passwords required as ClearText. Fixes connections issues with Azure Database for PostgreSQL.
-- Added a new boolean parameter in connection as 'allowClearTextPassword' to activate / deactivate the feature.
+- Support for clear text passwords using a boolean parameter in connection as 'allowClearTextPassword' to activate / deactivate the feature. [#20](https://github.com/isoos/postgresql-dart/pull/20).
 
 ## 2.4.2
 

--- a/lib/src/auth/auth.dart
+++ b/lib/src/auth/auth.dart
@@ -3,10 +3,11 @@ import 'package:sasl_scram/sasl_scram.dart';
 
 import '../../postgres.dart';
 import '../server_messages.dart';
+import 'clearText_authenticator.dart';
 import 'md5_authenticator.dart';
 import 'sasl_authenticator.dart';
 
-enum AuthenticationScheme { MD5, SCRAM_SHA_256 }
+enum AuthenticationScheme { MD5, SCRAM_SHA_256, CLEAR }
 
 abstract class PostgresAuthenticator {
   static String? name;
@@ -27,6 +28,8 @@ PostgresAuthenticator createAuthenticator(PostgreSQLConnection connection,
           username: connection.username, password: connection.password);
       return PostgresSaslAuthenticator(
           connection, ScramAuthenticator('SCRAM-SHA-256', sha256, credentials));
+    case AuthenticationScheme.CLEAR:
+      return ClearAuthenticator(connection);
     default:
       throw PostgreSQLException("Authenticator wasn't specified");
   }

--- a/lib/src/auth/auth.dart
+++ b/lib/src/auth/auth.dart
@@ -3,7 +3,7 @@ import 'package:sasl_scram/sasl_scram.dart';
 
 import '../../postgres.dart';
 import '../server_messages.dart';
-import 'clearText_authenticator.dart';
+import 'clear_text_authenticator.dart';
 import 'md5_authenticator.dart';
 import 'sasl_authenticator.dart';
 

--- a/lib/src/auth/clearText_authenticator.dart
+++ b/lib/src/auth/clearText_authenticator.dart
@@ -1,0 +1,33 @@
+import 'package:buffer/buffer.dart';
+
+import '../../postgres.dart';
+import '../client_messages.dart';
+import '../server_messages.dart';
+import '../utf8_backed_string.dart';
+import 'auth.dart';
+
+class ClearAuthenticator extends PostgresAuthenticator{
+  ClearAuthenticator(PostgreSQLConnection connection) : super(connection);
+
+  @override
+  void onMessage(AuthenticationMessage message) {
+    final authMessage = ClearMessage(connection.password!);
+    connection.socket!.add(authMessage.asBytes());
+  }
+
+}
+class ClearMessage extends ClientMessage {
+  UTF8BackedString? _authString;
+
+  ClearMessage(String password) {
+    _authString = UTF8BackedString(password);
+  }
+
+  @override
+  void applyToBuffer(ByteDataWriter buffer) {
+    buffer.writeUint8(ClientMessage.PasswordIdentifier);
+    final length = 5 + _authString!.utf8Length;
+    buffer.writeUint32(length);
+    _authString!.applyToBuffer(buffer);
+  }
+}

--- a/lib/src/auth/clear_text_authenticator.dart
+++ b/lib/src/auth/clear_text_authenticator.dart
@@ -6,7 +6,7 @@ import '../server_messages.dart';
 import '../utf8_backed_string.dart';
 import 'auth.dart';
 
-class ClearAuthenticator extends PostgresAuthenticator{
+class ClearAuthenticator extends PostgresAuthenticator {
   ClearAuthenticator(PostgreSQLConnection connection) : super(connection);
 
   @override
@@ -14,8 +14,8 @@ class ClearAuthenticator extends PostgresAuthenticator{
     final authMessage = ClearMessage(connection.password!);
     connection.socket!.add(authMessage.asBytes());
   }
-
 }
+
 class ClearMessage extends ClientMessage {
   UTF8BackedString? _authString;
 

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -39,6 +39,7 @@ class PostgreSQLConnection extends Object
   /// [queryTimeoutInSeconds] refers to the default timeout for [PostgreSQLExecutionContext]'s execute and query methods.
   /// [timeZone] is the timezone the connection is in. Defaults to 'UTC'.
   /// [useSSL] when true, uses a secure socket when connecting to a PostgreSQL database.
+  /// [allowClearTextPassword] when true, allows sending the password during authentication in clear text. Use only when required by the database server and under encrypted connections, this feature may lead to security issues
   PostgreSQLConnection(
     this.host,
     this.port,
@@ -50,6 +51,7 @@ class PostgreSQLConnection extends Object
     this.timeZone = 'UTC',
     this.useSSL = false,
     this.isUnixSocket = false,
+    this.allowClearTextPassword = false,
   }) {
     _connectionState = _PostgreSQLConnectionStateClosed();
     _connectionState.connection = this;
@@ -90,6 +92,9 @@ class PostgreSQLConnection extends Object
 
   /// If true, connection is made via unix socket.
   final bool isUnixSocket;
+
+  /// If true, allows password in clear text for aunthentication
+  final bool allowClearTextPassword;
 
   /// Stream of notification from the database.
   ///

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -39,7 +39,7 @@ class PostgreSQLConnection extends Object
   /// [queryTimeoutInSeconds] refers to the default timeout for [PostgreSQLExecutionContext]'s execute and query methods.
   /// [timeZone] is the timezone the connection is in. Defaults to 'UTC'.
   /// [useSSL] when true, uses a secure socket when connecting to a PostgreSQL database.
-  /// [allowClearTextPassword] when true, allows sending the password during authentication in clear text. Use only when required by the database server and under encrypted connections, this feature may lead to security issues
+  /// [allowClearTextPassword] when true, allows sending the password during authentication in clear text. Use only when required by the database server and under encrypted connections, this feature may lead to security issues.
   PostgreSQLConnection(
     this.host,
     this.port,
@@ -93,7 +93,7 @@ class PostgreSQLConnection extends Object
   /// If true, connection is made via unix socket.
   final bool isUnixSocket;
 
-  /// If true, allows password in clear text for aunthentication
+  /// If true, allows password in clear text for authentication.
   final bool allowClearTextPassword;
 
   /// Stream of notification from the database.

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -115,8 +115,7 @@ class _PostgreSQLConnectionStateAuthenticating
             _authenticator =
                 createAuthenticator(connection!, AuthenticationScheme.CLEAR);
             continue authMsg;
-          }
-          else {
+          } else {
             break;
           }
         case AuthenticationMessage.KindSASL:

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -110,6 +110,15 @@ class _PostgreSQLConnectionStateAuthenticating
           _authenticator =
               createAuthenticator(connection!, AuthenticationScheme.MD5);
           continue authMsg;
+        case AuthenticationMessage.KindClearTextPassword:
+          if (connection!.allowClearTextPassword) {
+            _authenticator =
+                createAuthenticator(connection!, AuthenticationScheme.CLEAR);
+            continue authMsg;
+          }
+          else {
+            break;
+          }
         case AuthenticationMessage.KindSASL:
           _authenticator = createAuthenticator(
               connection!, AuthenticationScheme.SCRAM_SHA_256);
@@ -119,10 +128,6 @@ class _PostgreSQLConnectionStateAuthenticating
         case AuthenticationMessage.KindSASLFinal:
           _authenticator.onMessage(message);
           return this;
-        case AuthenticationMessage.KindClearTextPassword:
-          _authenticator =
-              createAuthenticator(connection!, AuthenticationScheme.CLEAR);
-          continue authMsg;
       }
 
       completer.completeError(PostgreSQLException(

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -116,6 +116,8 @@ class _PostgreSQLConnectionStateAuthenticating
                 createAuthenticator(connection!, AuthenticationScheme.CLEAR);
             continue authMsg;
           } else {
+            completer.completeError(PostgreSQLException(
+                'type ${message.type} connections disabled. Set AllowClearTextPassword flag on PostgreSQLConnection to enable this feature.'));
             break;
           }
         case AuthenticationMessage.KindSASL:

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -119,6 +119,10 @@ class _PostgreSQLConnectionStateAuthenticating
         case AuthenticationMessage.KindSASLFinal:
           _authenticator.onMessage(message);
           return this;
+        case AuthenticationMessage.KindClearTextPassword:
+          _authenticator =
+              createAuthenticator(connection!, AuthenticationScheme.CLEAR);
+          continue authMsg;
       }
 
       completer.completeError(PostgreSQLException(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 2.4.2
+version: 2.4.3
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:


### PR DESCRIPTION
Adds the option for clear text password authentication.

Fixes connections to Azure Database for PostgreSQL.

I created a new boolean parameter at the time of creating the connection called allowClearTextPassword default to false to enable this kind of authentication for the connection.

According to https://www.postgresql.org/docs/11/protocol-flow.html#id-1.10.5.7.3 flow, this patch just returns the password to the server when requested a clear text password after a connection attempt.

For the structure of the message I didn't quite got the grasp of the byte formatting, but replicated the structure used for md5 as it follows a similar message flow. Need review on this to guarantee it is working. Local testing showed no problem.

TODO 1: I could not come up with tests, as there should be a SQL server running with clear text password request configuration I cannot replicate. Please advise on whether such server exists or how could I write the necessary tests. I have successfully tested the changes under our environment, for both queries and transactions of every type.

TODO 2: There may be security concerns about using clear text passwords I am not aware of. Right now we have an open ticket with Microsoft regarding this issue. Note that in this environment, the connections are performed within a private cloud cluster and encrypted, thus making the password encryption non necessary.