### PR TITLE
Allow manual transaction management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.6
+
+- Fix crash when manually issuing a transaction statement like `BEGIN` without
+  using the high-level transaction APIs. [#47](https://github.com/isoos/postgresql-dart/pull/47) by [simolus3](https://github.com/simolus3).
+
 ## 2.4.5
 
 - Added support for boolean arrays. [#41](https://github.com/isoos/postgresql-dart/pull/41) by [slightfoot](https://github.com/slightfoot).

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -275,7 +275,7 @@ class _PostgreSQLConnectionStateBusy extends _PostgreSQLConnectionState {
       if (message.state == ReadyForQueryMessage.StateTransactionError) {
         query.completeError(returningException!);
         return _PostgreSQLConnectionStateReadyInTransaction(
-            query.transaction as _TransactionProxy);
+            query.transaction as _PostgreSQLExecutionContextMixin);
       }
       if (returningException != null) {
         query.completeError(returningException!);
@@ -285,7 +285,7 @@ class _PostgreSQLConnectionStateBusy extends _PostgreSQLConnectionState {
 
       if (message.state == ReadyForQueryMessage.StateTransaction) {
         return _PostgreSQLConnectionStateReadyInTransaction(
-            query.transaction as _TransactionProxy);
+            query.transaction as _PostgreSQLExecutionContextMixin);
       }
 
       return _PostgreSQLConnectionStateIdle();
@@ -314,7 +314,7 @@ class _PostgreSQLConnectionStateReadyInTransaction
     extends _PostgreSQLConnectionState {
   _PostgreSQLConnectionStateReadyInTransaction(this.transaction);
 
-  _TransactionProxy transaction;
+  _PostgreSQLExecutionContextMixin transaction;
 
   @override
   _PostgreSQLConnectionState onEnter() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 2.4.5
+version: 2.4.6
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:

--- a/test/transaction_test.dart
+++ b/test/transaction_test.dart
@@ -633,5 +633,16 @@ void main() {
       });
       expect(result, []);
     });
+
+    test('can start transactions manually', () async {
+      await conn.execute('BEGIN');
+      await conn.execute(
+        'INSERT INTO t VALUES (@a)',
+        substitutionValues: {'a': 123},
+      );
+      await conn.execute('ROLLBACK');
+
+      await expectLater(conn.query('SELECT * FROM t'), completion(isEmpty));
+    });
   });
 }


### PR DESCRIPTION
The connection FSM expected a `_TransactionProxy` when receiving transaction messages, but it's actually safe to just expect a general execution context implementation.

Closes #43.