### PR TITLE
Add Support for Streaming Replication Protocol 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ doc/api/
 *.iml
 *.ipr
 *.iws
+
+# VS Code IDE
+.vscode/

--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -1,0 +1,6 @@
+library postgres.messages;
+
+export 'src/client_messages.dart';
+export 'src/logical_replication_messages.dart';
+export 'src/server_messages.dart';
+export 'src/shared_messages.dart';

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -3,5 +3,6 @@ library postgres;
 export 'src/connection.dart';
 export 'src/execution_context.dart';
 export 'src/models.dart';
+export 'src/replication.dart' show ReplicationMode, LogicalDecodingPlugin;
 export 'src/substituter.dart';
 export 'src/types.dart';

--- a/lib/src/client_messages.dart
+++ b/lib/src/client_messages.dart
@@ -1,9 +1,13 @@
 import 'dart:typed_data';
 
 import 'package:buffer/buffer.dart';
+import 'package:postgres/src/time_converters.dart';
 
 import 'constants.dart';
 import 'query.dart';
+import 'replication.dart';
+import 'shared_messages.dart';
+import 'types.dart';
 import 'utf8_backed_string.dart';
 
 abstract class ClientMessage {
@@ -39,11 +43,14 @@ class StartupMessage extends ClientMessage {
   final UTF8BackedString? _username;
   final UTF8BackedString _databaseName;
   final UTF8BackedString _timeZone;
+  final UTF8BackedString _replication;
 
-  StartupMessage(String databaseName, String timeZone, {String? username})
+  StartupMessage(String databaseName, String timeZone,
+      {String? username, ReplicationMode replication = ReplicationMode.none})
       : _databaseName = UTF8BackedString(databaseName),
         _timeZone = UTF8BackedString(timeZone),
-        _username = username == null ? null : UTF8BackedString(username);
+        _username = username == null ? null : UTF8BackedString(username),
+        _replication = UTF8BackedString(replication.value);
 
   @override
   void applyToBuffer(ByteDataWriter buffer) {
@@ -55,12 +62,22 @@ class StartupMessage extends ClientMessage {
       variableLength += _username!.utf8Length + 1;
     }
 
+    if (_replication.string != ReplicationMode.none.value) {
+      fixedLength += UTF8ByteConstants.replication.length;
+      variableLength += _replication.utf8Length + 1;
+    }
+
     buffer.writeInt32(fixedLength + variableLength);
     buffer.writeInt32(ClientMessage.ProtocolVersion);
 
     if (_username != null) {
       buffer.write(UTF8ByteConstants.user);
       _username!.applyToBuffer(buffer);
+    }
+
+    if (_replication.string != ReplicationMode.none.value) {
+      buffer.write(UTF8ByteConstants.replication);
+      _replication.applyToBuffer(buffer);
     }
 
     buffer.write(UTF8ByteConstants.database);
@@ -220,5 +237,93 @@ class SyncMessage extends ClientMessage {
   void applyToBuffer(ByteDataWriter buffer) {
     buffer.writeUint8(ClientMessage.SyncIdentifier);
     buffer.writeUint32(4);
+  }
+}
+
+class StandbyStatusUpdateMessage extends ClientMessage
+    implements ReplicationMessage {
+  /// The WAL position that's been locally written
+  final LSN walWritePosition;
+
+  /// The WAL position that's been locally flushed
+  late final LSN walFlushPosition;
+
+  /// The WAL position that's been locally applied
+  late final LSN walApplyPosition;
+
+  /// Client system clock time
+  late final DateTime clientTime;
+
+  /// Request server to reply immediately.
+  final bool mustReply;
+
+  /// StandbyStatusUpdate to the PostgreSQL server.
+  ///
+  /// The only required field is [walWritePosition]. If either [walFlushPosition]
+  /// or [walApplyPosition] are `null`, [walWritePosition] will be assigned to them.
+  /// If [clientTime], then the current time is used.
+  ///
+  /// When sending this message, it must be wrapped within [CopyDataMessage]
+  StandbyStatusUpdateMessage({
+    required this.walWritePosition,
+    LSN? walFlushPosition,
+    LSN? walApplyPosition,
+    DateTime? clientTime,
+    this.mustReply = false,
+  }) {
+    this.walFlushPosition = walFlushPosition ?? walWritePosition;
+    this.walApplyPosition = walApplyPosition ?? walWritePosition;
+    this.clientTime = clientTime ?? DateTime.now().toUtc();
+  }
+
+  @override
+  void applyToBuffer(ByteDataWriter buffer) {
+    buffer.writeUint8(ReplicationMessage.standbyStatusUpdateIdentifier);
+    buffer.writeUint64(walWritePosition.value);
+    buffer.writeUint64(walFlushPosition.value);
+    buffer.writeUint64(walApplyPosition.value);
+    buffer.writeUint64(dateTimeToMicrosecondsSinceY2k(clientTime));
+    buffer.writeUint8(mustReply ? 1 : 0);
+  }
+}
+
+class HotStandbyFeedbackMessage extends ClientMessage
+    implements ReplicationMessage {
+  /// The client's system clock at the time of transmission, as microseconds since midnight on 2000-01-01.
+  final DateTime clientTime;
+
+  /// The standby's current global xmin, excluding the catalog_xmin from any
+  /// replication slots. If both this value and the following catalog_xmin are 0
+  /// this is treated as a notification that Hot Standby feedback will no longer
+  /// be sent on this connection. Later non-zero messages may reinitiate the
+  /// feedback mechanism
+  final int currentGlobalXmin;
+
+  /// The epoch of the global xmin xid on the standby.
+  final int epochGlobalXminXid;
+
+  /// The lowest catalog_xmin of any replication slots on the standby. Set to 0
+  /// if no catalog_xmin exists on the standby or if hot standby feedback is
+  /// being disabled.
+  final int lowestCatalogXmin;
+
+  /// The epoch of the catalog_xmin xid on the standby.
+  final int epochCatalogXminXid;
+
+  HotStandbyFeedbackMessage(
+      this.clientTime,
+      this.currentGlobalXmin,
+      this.epochGlobalXminXid,
+      this.lowestCatalogXmin,
+      this.epochCatalogXminXid);
+
+  @override
+  void applyToBuffer(ByteDataWriter buffer) {
+    buffer.writeUint8(ReplicationMessage.hotStandbyFeedbackIdentifier);
+    buffer.writeUint64(dateTimeToMicrosecondsSinceY2k(clientTime));
+    buffer.writeUint32(currentGlobalXmin);
+    buffer.writeUint32(epochGlobalXminXid);
+    buffer.writeUint32(lowestCatalogXmin);
+    buffer.writeUint32(epochCatalogXminXid);
   }
 }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -124,12 +124,12 @@ class PostgreSQLConnection extends Object
   /// to [Notification.processID].
   Stream<Notification> get notifications => _notifications.stream;
 
-  /// Stream of server messages 
-  /// 
+  /// Stream of server messages
+  ///
   /// Listen to this [Stream] to receive events for all PostgreSQL server messages
-  /// 
-  /// This includes all messages whether from Extended Query Protocol, Simple Query Protocol 
-  /// or Streaming Replication Protocol. 
+  ///
+  /// This includes all messages whether from Extended Query Protocol, Simple Query Protocol
+  /// or Streaming Replication Protocol.
   Stream<ServerMessage> get messages => _messages.stream;
 
   /// Reports on the latest known status of the connection: whether it was open or failed for some reason.
@@ -220,6 +220,19 @@ class PostgreSQLConnection extends Object
   ///
   /// After the returned [Future] completes, this connection can no longer be used to execute queries. Any queries in progress or queued are cancelled.
   Future close() => _close();
+
+  /// Adds a Client Message to the existing connection
+  ///
+  /// This is a low level API and the message must follow the protocol of this
+  /// connection. It's the responsiblity of the caller to ensure this message
+  /// does not interfere with any running queries or transactions.
+  void addMessage(ClientMessage message) {
+    if (isClosed) {
+      throw PostgreSQLException(
+          'Attempting to add a message, but connection is not open.');
+    }
+    _socket!.add(message.asBytes());
+  }
 
   /// Executes a series of queries inside a transaction on this connection.
   ///

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -49,7 +49,8 @@ class _PostgreSQLConnectionStateSocketConnected
   _PostgreSQLConnectionState onEnter() {
     final startupMessage = StartupMessage(
         connection!.databaseName, connection!.timeZone,
-        username: connection!.username);
+        username: connection!.username,
+        replication: connection!.replicationMode);
 
     connection!._socket!.add(startupMessage.asBytes());
 
@@ -205,7 +206,7 @@ class _PostgreSQLConnectionStateIdle extends _PostgreSQLConnectionState {
 
   _PostgreSQLConnectionState processQuery(Query<dynamic> q) {
     try {
-      if (q.onlyReturnAffectedRowCount) {
+      if (q.onlyReturnAffectedRowCount || q.useSendSimple) {
         q.sendSimple(connection!._socket!);
         return _PostgreSQLConnectionStateBusy(q);
       }
@@ -333,7 +334,7 @@ class _PostgreSQLConnectionStateReadyInTransaction
 
   _PostgreSQLConnectionState processQuery(Query<dynamic> q) {
     try {
-      if (q.onlyReturnAffectedRowCount) {
+      if (q.onlyReturnAffectedRowCount || q.useSendSimple) {
         q.sendSimple(connection!._socket!);
         return _PostgreSQLConnectionStateBusy(q);
       }

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -21,4 +21,18 @@ class UTF8ByteConstants {
   ];
   static const utf8 = <int>[85, 84, 70, 56, 0];
   static const timeZone = <int>[84, 105, 109, 101, 90, 111, 110, 101, 0];
+  static const replication = <int>[
+    114,
+    101,
+    112,
+    108,
+    105,
+    99,
+    97,
+    116,
+    105,
+    111,
+    110,
+    0
+  ];
 }

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -85,6 +85,25 @@ abstract class PostgreSQLExecutionContext {
       {Map<String, dynamic>? substitutionValues,
       bool? allowReuse,
       int? timeoutInSeconds});
+
+  /// Executes a simple query on this context.
+  ///
+  /// Unlike [execute], if the executed query returns data, then this method
+  /// returns [PostgreSQLResult]. If the query does not return data, then
+  /// the affected row count is returned as [int].
+  ///
+  /// Unlike [query], all column values will be of type [String] even if they
+  /// have different type in the database. For instance, the value of an int4
+  /// column will be returned as a [String] instead of an [int]. This a simple
+  /// query limitation.
+  ///
+  /// This method is useful during the Streaming Replication Mode since the
+  /// extended query protocol cannot be used in a replication connection. In
+  /// such case, when data must be retrieved from the database, this method
+  /// can be safely used.
+  Future<dynamic> executeSimple(String fmtString,
+      {Map<String, dynamic>? substitutionValues = const {},
+      int? timeoutInSeconds});
 }
 
 /// A description of a column.

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -88,20 +88,25 @@ abstract class PostgreSQLExecutionContext {
 
   /// Executes a simple query on this context.
   ///
-  /// Unlike [execute], if the executed query returns data, then this method
-  /// returns [PostgreSQLResult]. If the query does not return data, then
-  /// the affected row count is returned as [int].
+  /// This method is similar to [execute] except that it'll return all the data.
+  /// That is, when the query result contains data, the method will return a
+  /// [PostgreSQLResult]. If the query does not return data, then the affected row
+  /// count is returned as [int].
   ///
-  /// Unlike [query], all column values will be of type [String] even if they
-  /// have different type in the database. For instance, the value of an int4
-  /// column will be returned as a [String] instead of an [int]. This a simple
-  /// query limitation.
+  /// Unlike [query], this method uses the Simple Query Protocol. that means,
+  /// all values will be of type [String] even if they have different type in the
+  /// database. For instance, the value of an `int4` column will be returned as
+  /// a [String] instead of an [int].
+  ///
+  /// This method uses the least efficient and less secure command for executing
+  /// queries in the PostgreSQL protocol; [query] is preferred for queries that
+  /// will be executed more than once, will contain user input, or return rows.
   ///
   /// This method is useful during the Streaming Replication Mode since the
-  /// extended query protocol cannot be used in a replication connection. In
-  /// such case, when data must be retrieved from the database, this method
-  /// can be safely used.
-  Future<dynamic> executeSimple(String fmtString,
+  /// Extended Query Protocol (i.e. [query] and [mappedResultsQuery]) cannot be
+  /// used in a replication connection. In such case, when the result of a query
+  /// is necessary to be retrieved, this method can be used instead of [execute].
+  Future<dynamic> simpleQuery(String fmtString,
       {Map<String, dynamic>? substitutionValues = const {},
       int? timeoutInSeconds});
 }

--- a/lib/src/logical_replication_messages.dart
+++ b/lib/src/logical_replication_messages.dart
@@ -1,0 +1,630 @@
+// Credit:
+//    The majority of the replication implementation was ported from `pglogrepl`
+//    go package:
+//    https://github.com/jackc/pglogrepl/
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:buffer/buffer.dart';
+
+import 'package:postgres/messages.dart';
+
+import 'binary_codec.dart';
+import 'time_converters.dart';
+import 'types.dart';
+
+/// A base class for all [Logical Replication Message Formats][] from the server
+///
+/// [Logical Replication Message Formats]: https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
+abstract class LogicalReplicationMessage
+    implements ReplicationMessage, ServerMessage {}
+
+class XLogDataLogicalMessage extends XLogDataMessage {
+  late final LogicalReplicationMessage _message;
+
+  @override
+  LogicalReplicationMessage get data => _message;
+
+  XLogDataLogicalMessage(Uint8List bytes) : super(bytes) {
+    _message = parseLogicalReplicationMessage(this.bytes);
+  }
+
+  @override
+  String toString() => super.toString();
+}
+
+LogicalReplicationMessage parseLogicalReplicationMessage(Uint8List bytesList) {
+  final firstByte = bytesList.first;
+
+  /// `123` is '{' in bytes and it is the first byte for wal2json message
+  if (firstByte == 123) {
+    return Wal2JsonMessage(utf8.decode(bytesList));
+  }
+
+  final msgType = LogicalReplicationMessageTypes.fromByte(firstByte);
+  // the first byte is the msg type
+  final bytes = bytesList.sublist(1);
+
+  switch (msgType) {
+    case LogicalReplicationMessageTypes.Begin:
+      return BeginMessage(bytes);
+    case LogicalReplicationMessageTypes.Commit:
+      return CommitMessage(bytes);
+    case LogicalReplicationMessageTypes.Origin:
+      return OriginMessage(bytes);
+    case LogicalReplicationMessageTypes.Relation:
+      return RelationMessage(bytes);
+    case LogicalReplicationMessageTypes.Type:
+      return TypeMessage(bytes);
+    case LogicalReplicationMessageTypes.Insert:
+      return InsertMessage(bytes);
+    case LogicalReplicationMessageTypes.Update:
+      return UpdateMessage(bytes);
+    case LogicalReplicationMessageTypes.Delete:
+      return DeleteMessage(bytes);
+    case LogicalReplicationMessageTypes.Truncate:
+      return TruncateMessage(bytes);
+    case LogicalReplicationMessageTypes.Unsupported:
+    default:
+      return UnknownLogicalReplicationMessage(bytes);
+  }
+}
+
+enum LogicalReplicationMessageTypes {
+  Begin('B'),
+  Commit('C'),
+  Origin('O'),
+  Relation('R'),
+  Type('Y'),
+  Insert('I'),
+  Update('U'),
+  Delete('D'),
+  Truncate('T'),
+  Unsupported('');
+
+  final String id;
+  const LogicalReplicationMessageTypes(this.id);
+
+  static LogicalReplicationMessageTypes fromID(String id) {
+    return LogicalReplicationMessageTypes.values.firstWhere(
+      (element) => element.id == id,
+      orElse: () => LogicalReplicationMessageTypes.Unsupported,
+    );
+  }
+
+  static LogicalReplicationMessageTypes fromByte(int byte) {
+    return fromID(String.fromCharCode(byte));
+  }
+}
+
+class Wal2JsonMessage implements LogicalReplicationMessage {
+  final String json;
+
+  Wal2JsonMessage(this.json);
+
+  @override
+  String toString() => json;
+}
+
+class UnknownLogicalReplicationMessage implements LogicalReplicationMessage {
+  final Uint8List bytes;
+
+  UnknownLogicalReplicationMessage(this.bytes);
+
+  @override
+  String toString() => 'UnknownLogicalReplicationMessage(bytes: $bytes)';
+}
+
+class BeginMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Begin;
+
+  /// The final LSN of the transaction.
+  late final LSN finalLSN;
+
+  /// The commit timestamp of the transaction.
+  late final DateTime commitTime;
+
+  /// The transaction id
+  late final int xid;
+
+  BeginMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    // reading order matters
+    finalLSN = reader.readLSN();
+    commitTime = reader.readTime();
+    xid = reader.readUint32();
+  }
+
+  @override
+  String toString() =>
+      'BeginMessage(finalLSN: $finalLSN, commitTime: $commitTime, xid: $xid)';
+}
+
+// CommitMessage is a commit message.
+class CommitMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Commit;
+
+  // Flags currently unused (must be 0).
+  late final int flags;
+
+  /// The LSN of the commit.
+  late final LSN commitLSN;
+
+  /// The end LSN of the transaction.
+  late final LSN transactionEndLSN;
+
+  /// The commit timestamp of the transaction.
+  late final DateTime commitTime;
+
+  CommitMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    // reading order matters
+    flags = reader.readUint8();
+    commitLSN = reader.readLSN();
+    transactionEndLSN = reader.readLSN();
+    commitTime = reader.readTime();
+
+    // TODO: figure out if xid is part of this (maybe check reader.remainingLength)
+    // xid = reader.readUint32();
+  }
+
+  @override
+  String toString() {
+    return 'CommitMessage(flags: $flags, commitLSN: $commitLSN, transactionEndLSN: $transactionEndLSN, commitTime: $commitTime)';
+  }
+}
+
+class OriginMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Origin;
+
+  /// The LSN of the commit on the origin server.
+  late final LSN commitLSN;
+
+  late final String name;
+
+  OriginMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    // reading order matters
+    commitLSN = reader.readLSN();
+    name = reader.decodeString();
+  }
+
+  @override
+  String toString() => 'OriginMessage(commitLSN: $commitLSN, name: $name)';
+}
+
+class RelationMessageColumn {
+  /// Flags for the column. Currently can be either 0 for no flags or 1 which
+  /// marks the column as part of the key.
+  final int flags;
+
+  final String name;
+
+  /// The ID of the column's data type.
+  final int dataType;
+
+  /// type modifier of the column (atttypmod).
+  final int typeModifier;
+
+  RelationMessageColumn({
+    required this.flags,
+    required this.name,
+    required this.dataType,
+    required this.typeModifier,
+  });
+
+  @override
+  String toString() {
+    return 'RelationMessageColumn(flags: $flags, name: $name, dataType: $dataType, typeModifier: $typeModifier)';
+  }
+}
+
+class RelationMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Relation;
+  late final int relationID;
+  late final String nameSpace;
+  late final String relationName;
+  late final int replicaIdentity;
+  late final int columnNum;
+  late final columns = <RelationMessageColumn>[];
+
+  RelationMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    // reading order matters
+    relationID = reader.readUint32();
+    nameSpace = reader.decodeString();
+    relationName = reader.decodeString();
+    replicaIdentity = reader.readUint8();
+    columnNum = reader.readUint16();
+
+    for (var i = 0; i < columnNum; i++) {
+      // reading order matters
+      final flags = reader.readUint8();
+      final name = reader.decodeString();
+      final dataType = reader.readUint32();
+      final typeModifier = reader.readUint32();
+      columns.add(
+        RelationMessageColumn(
+          flags: flags,
+          name: name,
+          dataType: dataType,
+          typeModifier: typeModifier,
+        ),
+      );
+    }
+  }
+
+  @override
+  String toString() {
+    return 'RelationMessage(relationID: $relationID, nameSpace: $nameSpace, relationName: $relationName, replicaIdentity: $replicaIdentity, columnNum: $columnNum, columns: $columns)';
+  }
+}
+
+class TypeMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Type;
+
+  late final int dataType; // oid -- TODO: create a string getter
+
+  late final String nameSpace;
+
+  late final String name;
+
+  TypeMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    // reading order matters
+    dataType = reader.readUint32();
+    nameSpace = reader.decodeString();
+    name = reader.decodeString();
+  }
+
+  @override
+  String toString() =>
+      'TypeMessage(dataType: $dataType, nameSpace: $nameSpace, name: $name)';
+}
+
+enum TupleDataType {
+  nullType('n'),
+  toastType('u'),
+  textType('t'),
+  binaryType('b');
+
+  final String id;
+  const TupleDataType(this.id);
+  static TupleDataType fromID(String id) {
+    // TODO: handle unknown types to prevent state error
+    return TupleDataType.values.firstWhere((element) => element.id == id);
+  }
+
+  static TupleDataType fromByte(int byte) {
+    return fromID(String.fromCharCode(byte));
+  }
+}
+
+class TupleDataColumn {
+  /// Indicates the how does the data is stored.
+  ///	 Byte1('n') Identifies the data as NULL value.
+  ///	 Or
+  ///	 Byte1('u') Identifies unchanged TOASTed value (the actual value is not sent).
+  ///	 Or
+  ///	 Byte1('t') Identifies the data as text formatted value.
+  ///	 Or
+  ///	 Byte1('b') Identifies the data as binary value.
+  // TODO: should this be TupleDataType?
+  final int dataType;
+  final int length;
+
+  String get dataTypeName =>
+      PostgresBinaryDecoder.typeMap[dataType]?.name ?? dataType.toString();
+
+  /// Data is the value of the column, in text format.
+  /// n is the above length.
+  final String data; // TODO should Uint8List instead?
+
+  TupleDataColumn({
+    required this.dataType,
+    required this.length,
+    required this.data,
+  });
+
+  @override
+  String toString() =>
+      'TupleDataColumn(dataType: $dataTypeName, length: $length, data: $data)';
+}
+
+class TupleData {
+  /// The message type
+  // late final ReplicationMessageTypes baseMessage;
+
+  late final int columnNum;
+  late final columns = <TupleDataColumn>[];
+
+  /// TupleData does not consume the entire bytes
+  ///
+  /// It'll read until the types are generated.
+  TupleData(ByteDataReader reader) {
+    columnNum = reader.readUint16();
+    for (var i = 0; i < columnNum; i++) {
+      // reading order matters
+      final dataType = reader.readUint8();
+      final tupleDataType = TupleDataType.fromByte(dataType);
+      late final int length;
+      late final Uint8List data;
+      switch (tupleDataType) {
+        case TupleDataType.textType:
+        case TupleDataType.binaryType:
+          length = reader.readUint32();
+          data = reader.read(length);
+          break;
+        case TupleDataType.nullType:
+        case TupleDataType.toastType:
+          // TODO: confirm this
+          length = 0;
+          data = Uint8List(0);
+          break;
+      }
+      columns.add(
+        TupleDataColumn(
+          dataType: dataType,
+          length: length,
+          data: utf8.decode(data),
+        ),
+      );
+    }
+  }
+
+  @override
+  String toString() => 'TupleData(columnNum: $columnNum, columns: $columns)';
+}
+
+class InsertMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Insert;
+
+  /// The ID of the relation corresponding to the ID in the relation message.
+  late final int relationID;
+  late final TupleData tuple;
+
+  InsertMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    relationID = reader.readUint32();
+    final tupleType = reader.readUint8();
+    if (tupleType != 'N'.codeUnitAt(0)) {
+      throw Exception("InsertMessage must have 'N' tuple type");
+    }
+    tuple = TupleData(reader);
+  }
+
+  @override
+  String toString() => 'InsertMessage(relationID: $relationID, tuple: $tuple)';
+}
+
+enum UpdateMessageTuple {
+  noneType('0'), // This is Zero not the letter 'O'
+  keyType('K'),
+  oldType('O'),
+  newType('N');
+
+  final String id;
+  const UpdateMessageTuple(this.id);
+  static UpdateMessageTuple fromID(String id) {
+    // TODO: handle unknown types to prevent state error
+    return UpdateMessageTuple.values
+        .firstWhere((element) => element.id == id, orElse: () => noneType);
+  }
+
+  static UpdateMessageTuple fromByte(int byte) {
+    if (byte == 0) {
+      return noneType;
+    }
+    return fromID(String.fromCharCode(byte));
+  }
+}
+
+class UpdateMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Update;
+
+  late final int relationID;
+
+  /// OldTupleType
+  ///   Byte1('K'):
+  ///     Identifies the following TupleData submessage as a key.
+  ///     This field is optional and is only present if the update changed data
+  ///     in any of the column(s) that are part of the REPLICA IDENTITY index.
+  ///
+  ///   Byte1('O'):
+  ///     Identifies the following TupleData submessage as an old tuple.
+  ///     This field is optional & is only present if table in which the update
+  ///     happened has REPLICA IDENTITY set to FULL.
+  ///
+  /// The Update message may contain either a 'K' message part or an 'O' message
+  /// part or neither of them, but never both of them.
+  late final UpdateMessageTuple? oldTupleType;
+  late final TupleData? oldTuple;
+
+  /// NewTuple is the contents of a new tuple.
+  ///   Byte1('N'): Identifies the following TupleData message as a new tuple.
+  late final TupleData? newTuple;
+
+  UpdateMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    // reading order matters
+    relationID = reader.readUint32();
+    var tupleType = UpdateMessageTuple.fromByte(reader.readUint8());
+
+    if (tupleType == UpdateMessageTuple.oldType ||
+        tupleType == UpdateMessageTuple.keyType) {
+      oldTupleType = tupleType;
+      oldTuple = TupleData(reader);
+      tupleType = UpdateMessageTuple.fromByte(reader.readUint8());
+    } else {
+      oldTupleType = null;
+      oldTuple = null;
+    }
+
+    if (tupleType == UpdateMessageTuple.newType) {
+      newTuple = TupleData(reader);
+    } else {
+      throw Exception('Invalid Tuple Type for UpdateMessage');
+    }
+  }
+
+  @override
+  String toString() {
+    return 'UpdateMessage(relationID: $relationID, oldTupleType: $oldTupleType, oldTuple: $oldTuple, newTuple: $newTuple)';
+  }
+}
+
+enum DeleteMessageTuple {
+  keyType('K'),
+  oldType('O'),
+  unknown('');
+
+  final String id;
+  const DeleteMessageTuple(this.id);
+  static DeleteMessageTuple fromID(String id) {
+    // TODO: handle unknown types to prevent state error
+    return DeleteMessageTuple.values.firstWhere(
+      (element) => element.id == id,
+      orElse: () => unknown,
+    );
+  }
+
+  static DeleteMessageTuple fromByte(int byte) {
+    return fromID(String.fromCharCode(byte));
+  }
+}
+
+class DeleteMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Delete;
+
+  late final int relationID;
+
+  /// OldTupleType
+  ///   Byte1('K'):
+  ///     Identifies the following TupleData submessage as a key.
+  ///     This field is optional and is only present if the update changed data
+  ///     in any of the column(s) that are part of the REPLICA IDENTITY index.
+  ///
+  ///   Byte1('O'):
+  ///     Identifies the following TupleData submessage as an old tuple.
+  ///     This field is optional & is only present if table in which the update
+  ///     happened has REPLICA IDENTITY set to FULL.
+  ///
+  /// The Update message may contain either a 'K' message part or an 'O' message
+  /// part or neither of them, but never both of them.
+  late final DeleteMessageTuple oldTupleType;
+
+  /// NewTuple is the contents of a new tuple.
+  ///   Byte1('N'): Identifies the following TupleData message as a new tuple.
+  late final TupleData oldTuple;
+
+  DeleteMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    relationID = reader.readUint32();
+    oldTupleType = DeleteMessageTuple.fromByte(reader.readUint8());
+
+    switch (oldTupleType) {
+      case DeleteMessageTuple.keyType:
+      case DeleteMessageTuple.oldType:
+        oldTuple = TupleData(reader);
+        break;
+      default:
+        throw Exception('Unknown tuple type for DeleteMessage');
+    }
+  }
+
+  @override
+  String toString() =>
+      'DeleteMessage(relationID: $relationID, oldTupleType: $oldTupleType, oldTuple: $oldTuple)';
+}
+
+// see https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html
+enum TruncateOptions {
+  cascade(1),
+  restartIdentity(2),
+  none(0);
+
+  final int value;
+  const TruncateOptions(this.value);
+
+  static TruncateOptions fromValue(int value) {
+    return TruncateOptions.values
+        .firstWhere((element) => element.value == value, orElse: () => none);
+  }
+}
+
+class TruncateMessage implements LogicalReplicationMessage {
+  /// The message type
+  late final baseMessage = LogicalReplicationMessageTypes.Truncate;
+
+  late final int relationNum;
+
+  late final TruncateOptions option;
+
+  final relationIds = <int>[];
+
+  TruncateMessage(Uint8List bytes) {
+    final reader = ByteDataReader()..add(bytes);
+    relationNum = reader.readUint32();
+    option = TruncateOptions.fromValue(reader.readUint8());
+    for (var i = 0; i < relationNum; i++) {
+      final id = reader.readUint32();
+      relationIds.add(id);
+    }
+  }
+
+  @override
+  String toString() =>
+      'TruncateMessage(relationNum: $relationNum, option: $option, relationIds: $relationIds)';
+}
+
+/// Extension contain commonly used methods within this file
+extension on ByteDataReader {
+  // Uint8List remainingBytes() {
+  //   return read(remainingLength);
+  // }
+
+  LSN readLSN() {
+    return LSN(readUint64());
+  }
+
+  DateTime readTime() {
+    return dateTimeFromMicrosecondsSinceY2k(readUint64());
+  }
+
+  /// Decodes a string from reader current offset
+  ///
+  /// String type definition: https://www.postgresql.org/docs/current/protocol-message-types.html
+  /// String(s)
+  ///   A null-terminated string (C-style string). There is no specific length limitation on strings.
+  ///   If s is specified it is the exact value that will appear, otherwise the value is variable.
+  ///   Eg. String, String("user").
+  ///
+  /// If there is no null byte, return empty string.
+  String decodeString() {
+    var foundNullByte = false;
+    final string = <int>[];
+    while (remainingLength > 0) {
+      final byte = readUint8();
+      if (byte == 0) {
+        foundNullByte = true;
+        break;
+      }
+      string.add(byte);
+    }
+
+    if (!foundNullByte) {
+      return '';
+    }
+
+    return utf8.decode(string);
+  }
+}

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -21,9 +21,11 @@ class Query<T> {
     this.transaction,
     this.queryStackTrace, {
     this.onlyReturnAffectedRowCount = false,
+    this.useSendSimple = false,
   });
 
   final bool onlyReturnAffectedRowCount;
+  final bool useSendSimple;
 
   String? statementIdentifier;
 
@@ -139,6 +141,21 @@ class Query<T> {
 
   void addRow(List<Uint8List?> rawRowData) {
     if (onlyReturnAffectedRowCount || fieldDescriptions == null) {
+      return;
+    }
+
+    // Simple queries do not follow the same binary codecs. All values will be
+    // returned as strings. 
+    //
+    // For instance, a column can be defined as `int4` which is expected to be
+    // 4 bytes long (i.e. decoded using bytes.getUint32) but when using simple
+    // query (i.e. sendSimple), the value will be returned as a string.
+    //
+    // See response to:
+    // https://postgresql.org/message-id/17325-f45d35e03971e979%40postgresql.org
+    if (useSendSimple) {
+      final data = rawRowData.map((e) => utf8.decode(e!));
+      rows.add(data.toList());
       return;
     }
 

--- a/lib/src/replication.dart
+++ b/lib/src/replication.dart
@@ -1,0 +1,40 @@
+// TODO: these types could move to a common "connection_config.dart" file
+
+/// Streaming Replication Protocol Options
+///
+/// [physical] or [logical] are used to start the connection a streaming
+/// replication mode.
+///
+/// See [Protocol Replication][] for more details.
+///
+/// [Protocol Replication]: https://www.postgresql.org/docs/current/protocol-replication.html
+enum ReplicationMode {
+  physical('true'),
+  logical('database'),
+  none('false');
+
+  final String value;
+
+  const ReplicationMode(this.value);
+}
+
+/// The Logical Decoding Output Plugins For Streaming Replication
+///
+/// [pgoutput] is the standard logical decoding plugin that is built in
+/// PostgreSQL since version 10.
+///
+/// [wal2json] is a popular output plugin for logical decoding. The extension
+/// must be available on the database when using this output option. When using
+/// [wal2json] plugin, the following are some limitations:
+/// - the plug-in does not emit events for tables without primary keys
+/// - the plug-in does not support special values (NaN or infinity) for floating
+///   point types
+///
+/// For more info, see [wal2json repo][].
+///
+/// [wal2json repo]: https://github.com/eulerto/wal2json
+enum LogicalDecodingPlugin {
+  pgoutput,
+  wal2json,
+}
+

--- a/lib/src/shared_messages.dart
+++ b/lib/src/shared_messages.dart
@@ -1,0 +1,62 @@
+import 'dart:typed_data';
+
+import 'package:buffer/buffer.dart';
+
+import 'package:postgres/src/client_messages.dart';
+import 'package:postgres/src/server_messages.dart';
+
+/// An abstraction for all client and server replication messages
+///
+/// For more details, see [Streaming Replication Protocol][]
+///
+/// [Streaming Replication Protocol]: https://www.postgresql.org/docs/current/protocol-replication.html
+abstract class ReplicationMessage {
+  static const int primaryKeepAliveIdentifier = 107; // k 
+  static const int xLogDataIdentifier = 119; // w 
+  static const int hotStandbyFeedbackIdentifier = 104; // h 
+  static const int standbyStatusUpdateIdentifier = 114; // r
+}
+
+/// Messages that are shared between both the server and the client
+///
+/// For more details, see [Message Formats][]
+///
+/// [Message Formats]: https://www.postgresql.org/docs/current/protocol-message-formats.html
+abstract class SharedMessages extends ClientMessage implements ServerMessage {
+  static const int copyDoneIdentifier = 99; // c 
+  static const int copyDataIdentifier = 100; // d 
+}
+
+/// A COPY data message.
+class CopyDataMessage extends SharedMessages {
+  /// Data that forms part of a COPY data stream. Messages sent from the backend
+  /// will always correspond to single data rows, but messages sent by frontends
+  /// might divide the data stream arbitrarily.
+  final Uint8List bytes;
+
+  /// Length of message contents in bytes, including self (i.e. int32).
+  int get length => bytes.length + 4;
+
+  CopyDataMessage(this.bytes);
+
+  @override
+  void applyToBuffer(ByteDataWriter buffer) {
+    buffer.writeUint8(SharedMessages.copyDataIdentifier);
+    buffer.writeInt32(length);
+    buffer.write(bytes);
+  }
+}
+
+/// A COPY-complete indicator.
+class CopyDoneMessage extends SharedMessages {
+  ///  Length of message contents in bytes, including self.
+  late final int length;
+
+  CopyDoneMessage(this.length);
+
+  @override
+  void applyToBuffer(ByteDataWriter buffer) {
+    buffer.writeUint8(SharedMessages.copyDoneIdentifier);
+    buffer.writeInt32(length);
+  }
+}

--- a/lib/src/time_converters.dart
+++ b/lib/src/time_converters.dart
@@ -1,0 +1,12 @@
+const _microsecFromUnixEpochToY2K = 946684800 * 1000000;
+
+DateTime dateTimeFromMicrosecondsSinceY2k(int microSecondsSinceY2K) {
+  final microsecSinceUnixEpoch =
+      _microsecFromUnixEpochToY2K + microSecondsSinceY2K;
+  return DateTime.fromMicrosecondsSinceEpoch(microsecSinceUnixEpoch, isUtc: true);
+}
+
+int dateTimeToMicrosecondsSinceY2k(DateTime time) {
+  final microsecSinceUnixEpoch = time.toUtc().microsecondsSinceEpoch;
+  return microsecSinceUnixEpoch - _microsecFromUnixEpochToY2K;
+}

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -103,3 +103,54 @@ enum PostgreSQLDataType {
   /// Must be a [List] of encodable objects
   jsonbArray,
 }
+
+/// LSN is a PostgreSQL Log Sequence Number.
+///
+/// For more details, see: https://www.postgresql.org/docs/current/datatype-pg-lsn.html
+class LSN {
+  final int value;
+
+  /// Construct an LSN from a 64-bit integer.
+  LSN(this.value);
+
+  /// Construct an LSN from XXX/XXX format used by PostgreSQL
+  LSN.fromString(String string) : value = _parseLSNString(string);
+
+  /// Formats the LSN value into the XXX/XXX format which is the text format
+  /// used by PostgreSQL.
+  @override
+  String toString() {
+    return '${(value >> 32).toRadixString(16).toUpperCase()}/${value.toUnsigned(32).toRadixString(16).toUpperCase()}';
+  }
+
+  static int _parseLSNString(String string) {
+    int upperhalf;
+    int lowerhalf;
+    final halves = string.split('/');
+    if (halves.length != 2) {
+      throw Exception('Invalid LSN String was given ($string)');
+    }
+    upperhalf = int.parse(halves[0], radix: 16) << 32;
+    lowerhalf = int.parse(halves[1], radix: 16);
+
+    return (upperhalf + lowerhalf).toInt();
+  }
+
+  LSN operator +(LSN other) {
+    return LSN(value + other.value);
+  }
+
+  LSN operator -(LSN other) {
+    return LSN(value + other.value);
+  }
+
+  @override
+  bool operator ==(covariant LSN other) {
+    if (identical(this, other)) return true;
+
+    return other.value == value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.4.6
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   buffer: ^1.1.0

--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -10,8 +10,8 @@ import 'package:test/test.dart';
 import 'docker.dart';
 
 void main() {
+  usePostgresDocker();
   group('connection state', () {
-    usePostgresDocker();
 
     test('pre-open failure', () async {
       final conn = PostgreSQLConnection('localhost', 5432, 'dart_test',
@@ -107,6 +107,37 @@ void main() {
       expect(await conn.execute('select 1'), equals(1));
     });
 
+
+    test('Connect with no Replication mode', () async {
+      conn = PostgreSQLConnection('localhost', 5432, 'dart_test',
+          username: 'dart', password: 'dart', replicationMode: ReplicationMode.none);
+
+      await conn.open();
+
+      expect(await conn.execute('select 1'), equals(1));
+    });
+
+    test('Connect with logical Replication mode', () async {
+      conn = PostgreSQLConnection('localhost', 5432, 'dart_test',
+          username: 'dart', password: 'dart', replicationMode: ReplicationMode.logical);
+
+      await conn.open();
+
+      expect(await conn.execute('select 1'), equals(1));
+    });
+
+    // TODO: test with Replication.physical once `pg_hba.conf` entry 
+    //       for replication connection is setup 
+    // test('Connect with physical Replication mode', () async {
+    //   conn = PostgreSQLConnection('localhost', 5432, 'dart_test',
+    //       username: 'dart', password: 'dart', replication: ReplicationMode.physical);
+
+    //   await conn.open();
+
+    //   expect(await conn.execute('select 1'), equals(1));
+    // });
+
+
     test('SSL Connect with md5 or scram-sha-256 auth required', () async {
       conn = PostgreSQLConnection('localhost', 5432, 'dart_test',
           username: 'dart', password: 'dart', useSSL: true);
@@ -194,7 +225,7 @@ void main() {
       await conn.close();
       await Future.wait(futures);
       expect(errors.length, 5);
-      expect(errors.map((e) => e.message),
+      expect(errors.map((e) => e._message),
           everyElement(contains('Query cancelled')));
     });
 
@@ -222,7 +253,7 @@ void main() {
       await conn.close();
       await Future.wait(futures);
       expect(errors.length, 5);
-      expect(errors.map((e) => e.message),
+      expect(errors.map((e) => e._message),
           everyElement(contains('Query cancelled')));
     });
   });

--- a/test/docker.dart
+++ b/test/docker.dart
@@ -49,3 +49,8 @@ Future<bool> _isPostgresContainerRunning() async {
       .map((s) => s.trim())
       .contains(_kContainerName);
 }
+
+
+Future<void> restartContainer() async {
+   await Process.run('docker', ['restart', _kContainerName]);
+}

--- a/test/logical_replication_test.dart
+++ b/test/logical_replication_test.dart
@@ -92,7 +92,7 @@ void main() {
       await conn.execute('CREATE PUBLICATION $publicationName FOR ALL TABLES;');
 
       final sysInfoRes =
-          (await conn.executeSimple('IDENTIFY_SYSTEM;')) as PostgreSQLResult;
+          (await conn.simpleQuery('IDENTIFY_SYSTEM;')) as PostgreSQLResult;
 
       final xlogpos = sysInfoRes.first.toColumnMap()['xlogpos'] as String;
 

--- a/test/logical_replication_test.dart
+++ b/test/logical_replication_test.dart
@@ -1,0 +1,283 @@
+import 'dart:async';
+
+import 'package:postgres/messages.dart';
+import 'package:postgres/postgres.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+import 'docker.dart';
+
+final _tempTableQuery = '''
+create table if not exists temp (
+    id int GENERATED ALWAYS AS IDENTITY, 
+    value text,
+    PRIMARY KEY (id)
+    );
+''';
+
+const String _host = 'localhost';
+const int _port = 5432;
+const String _username = 'dart';
+const String _password = 'dart';
+const String _database = 'dart_test';
+
+// NOTES:
+//
+// - Two PostgreSQL connections are needed for testing replication.
+//    - One for listening to streaming replications (connection will be locked).
+//    - The other one to modify the database (e.g. insert, delete, update, truncate)
+//
+// - TODO: There's no tests for ReplicationMode.wal2json as the container needs
+//         to have wal2json plugin installed. Once that's taken care of, tests
+//         can be added.
+void main() {
+  usePostgresDocker();
+
+  group('test logical replication with pgoutput', () {
+    final logicalDecodingPlugin = LogicalDecodingPlugin.pgoutput;
+    final replicationMode = ReplicationMode.logical;
+    // use this for listening to messages
+    var conn = PostgreSQLConnection(
+      _host,
+      _port,
+      _database,
+      username: _username,
+      password: _password,
+      replicationMode: replicationMode,
+      logicalDecodingPlugin: logicalDecodingPlugin,
+    );
+
+    // use this for sending queries
+    final conn2 = PostgreSQLConnection(
+      _host,
+      _port,
+      _database,
+      username: _username,
+      password: _password,
+    );
+
+    setUpAll(() async {
+      await conn.open();
+
+      // Setup the database for replication
+      await conn.execute('ALTER SYSTEM SET wal_level = logical;');
+      await conn.execute('ALTER SYSTEM SET max_replication_slots = 5;');
+      await conn.execute('ALTER SYSTEM SET max_wal_senders=5;');
+
+      /// 'ALTER SYSTEM' statement requires restarting the database
+      /// An easy way is to restart the docker container
+      await conn.close();
+      await restartContainer();
+
+      // this is necessary as calling `conn.open()` won't work
+      conn = PostgreSQLConnection(
+        _host,
+        _port,
+        _database,
+        username: _username,
+        password: _password,
+        replicationMode: replicationMode,
+        logicalDecodingPlugin: logicalDecodingPlugin,
+      );
+
+      await Future.delayed(Duration(seconds: 1));
+      await conn.open();
+      await conn2.open();
+
+      await conn.execute(_tempTableQuery);
+
+      // create publication
+      final publicationName = 'test_publication';
+      await conn.execute('DROP PUBLICATION IF EXISTS $publicationName;');
+      await conn.execute('CREATE PUBLICATION $publicationName FOR ALL TABLES;');
+
+      final sysInfoRes =
+          (await conn.executeSimple('IDENTIFY_SYSTEM;')) as PostgreSQLResult;
+
+      final xlogpos = sysInfoRes.first.toColumnMap()['xlogpos'] as String;
+
+      // create replication slot
+      final slotName = 'a_test_slot';
+      await conn.execute('BEGIN READ ONLY ISOLATION LEVEL REPEATABLE READ');
+      // `TEMPORARY` will remove the slot after the connection is closed/dropped
+      await conn.execute(
+        'CREATE_REPLICATION_SLOT $slotName TEMPORARY LOGICAL ${logicalDecodingPlugin.name} USE_SNAPSHOT',
+      );
+      await conn.execute('COMMIT');
+
+      // start replication process
+      var statement = 'START_REPLICATION SLOT $slotName LOGICAL $xlogpos ';
+      switch (logicalDecodingPlugin) {
+        case LogicalDecodingPlugin.pgoutput:
+          statement +=
+              "(proto_version '1', publication_names '$publicationName')";
+          break;
+        case LogicalDecodingPlugin.wal2json:
+          statement += "(\"pretty-print\" 'false')";
+          break;
+      }
+
+      // This future will not complete until the replication process stops
+      // by closing the connection, an error or timing out.
+      // ignore: unawaited_futures
+      conn.execute(statement, timeoutInSeconds: 120).catchError((e) {
+        // this query will be cancelled once the connection is closed.
+        // no need to handle the error
+        return 0;
+      });
+
+      await Future.delayed(Duration(seconds: 1));
+    });
+
+    tearDownAll(() async {
+      // this will stop the streaming and delete the replication slot
+      await conn.close();
+      await conn2.close();
+    });
+
+    // BeginMessage -> InsertMessage -> CommitMessage
+    test('- Receive InsertMessage after insert statement', () async {
+      final stream = conn.messages
+          .where((event) => event is XLogDataMessage)
+          .map((event) => (event as XLogDataMessage).data)
+          // RelationMessage isn't always present (appears conditionally) so
+          // it's skipped when present
+          .where((event) => event is! RelationMessage)
+          .take(3);
+
+      late final StreamController controller;
+      controller = StreamController(
+        onListen: () async {
+          // don't await here otherwise what's after won't be executed.
+          final future = controller.addStream(stream);
+          await conn2.execute("insert into temp (value) values ('test');");
+          await future;
+          await controller.close();
+        },
+      );
+
+      final matchers = [
+        isA<BeginMessage>(),
+        isA<InsertMessage>(),
+        isA<CommitMessage>(),
+      ];
+
+      expect(controller.stream, emitsInAnyOrder(matchers));
+    });
+
+    // BeginMessage -> UpdateMessage -> CommitMessage
+    test('- Receive UpdateMessage after update statement', () async {
+      // insert data to be updated
+      await conn2.execute("insert into temp (value) values ('update_test');");
+      // wait to avoid capturing INSERT
+      await Future.delayed(Duration(seconds: 3));
+      final stream = conn.messages
+          .where((event) => event is XLogDataMessage)
+          .map((event) => (event as XLogDataMessage).data)
+          // RelationMessage isn't always present (appears conditionally) so
+          // it's skipped when present
+          .where((event) => event is! RelationMessage)
+          .take(3);
+
+      late final StreamController controller;
+      controller = StreamController(
+        onListen: () async {
+          // don't await here otherwise what's after won't be executed.
+          final future = controller.addStream(stream);
+          await conn2.execute(
+            "update temp set value = 'updated_test_value'"
+            "where value = 'update_test';",
+          );
+          await future;
+          await controller.close();
+        },
+      );
+
+      final matchers = [
+        isA<BeginMessage>(),
+        isA<UpdateMessage>(),
+        isA<CommitMessage>(),
+      ];
+
+      expect(controller.stream, emitsInAnyOrder(matchers));
+    });
+    // BeginMessage -> DeleteMessage -> CommitMessage
+    test('- Receive DeleteMessage after delete statement', () async {
+      // create table to be truncated
+      await conn2.execute("insert into temp (value) values ('update_test');");
+      // wait to avoid capturing INSERT
+      await Future.delayed(Duration(seconds: 3));
+      final stream = conn.messages
+          .where((event) => event is XLogDataMessage)
+          .map((event) => (event as XLogDataMessage).data)
+          // RelationMessage isn't always present (appears conditionally) so
+          // it's skipped when present
+          .where((event) => event is! RelationMessage)
+          .take(3);
+
+      late final StreamController controller;
+      controller = StreamController(
+        onListen: () async {
+          // don't await here otherwise what's after won't be executed.
+          final future = controller.addStream(stream);
+          await conn2.execute(
+            "delete from temp where value = 'update_test';",
+          );
+          await future;
+          await controller.close();
+        },
+      );
+
+      final matchers = [
+        isA<BeginMessage>(),
+        isA<DeleteMessage>(),
+        isA<CommitMessage>(),
+      ];
+
+      expect(controller.stream, emitsInAnyOrder(matchers));
+    });
+
+    // BeginMessage -> TruncateMessage -> CommitMessage
+    test('- Receive TruncateMessage after delete statement', () async {
+      final tableName = 'temp_truncate';
+      // insert data to be deleted
+      await conn2.execute('''
+create table if not exists $tableName (
+    id int GENERATED ALWAYS AS IDENTITY, 
+    value text,
+    PRIMARY KEY (id)
+    );
+''');
+      // wait to for a second
+      await Future.delayed(Duration(seconds: 1));
+      final stream = conn.messages
+          .where((event) => event is XLogDataMessage)
+          .map((event) => (event as XLogDataMessage).data)
+          // RelationMessage isn't always present (appears conditionally) so
+          // it's skipped when present
+          .where((event) => event is! RelationMessage)
+          .take(3);
+
+      late final StreamController controller;
+      controller = StreamController(
+        onListen: () async {
+          // don't await here otherwise what's after won't be executed.
+          final future = controller.addStream(stream);
+          await conn2.execute(
+            'truncate table $tableName;',
+          );
+          await future;
+          await controller.close();
+        },
+      );
+
+      final matchers = [
+        isA<BeginMessage>(),
+        isA<TruncateMessage>(),
+        isA<CommitMessage>(),
+      ];
+
+      expect(controller.stream, emitsInOrder(matchers));
+    });
+  });
+}

--- a/test/time_converter_test.dart
+++ b/test/time_converter_test.dart
@@ -1,0 +1,22 @@
+import 'package:postgres/src/time_converters.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('test time conversion from pg to dart and vice versa', () {
+    test('pgTimeToDateTime produces correct DateTime', () {
+      final timeFromPg = dateTimeFromMicrosecondsSinceY2k(0);
+
+      expect(timeFromPg.year, 2000);
+      expect(timeFromPg.month, 1);
+      expect(timeFromPg.day, 1);
+    });
+
+    test('dateTimeToPgTime produces correct microseconds since 2000-01-01', () {
+      // final timeFromPg = pgTimeToDateTime(0);
+      final dateTime = DateTime.utc(2000, 1, 1);
+      final pgTime = dateTimeToMicrosecondsSinceY2k(dateTime);
+      expect(pgTime, 0);
+    });
+  });
+}

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -1,0 +1,25 @@
+import 'package:postgres/postgres.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+// These two numbers are equal but in different formats
+// 
+// see: https://www.postgresql.org/docs/current/datatype-pg-lsn.html
+const _lsnStringSample = '16/B374D848';
+const _lsnIntegerSample = 97500059720;
+
+void main() {
+  group('LSN type', () {
+    test('- Can parse LSN String', () {
+      final lsn = LSN.fromString(_lsnStringSample);
+
+      expect(lsn.value, _lsnIntegerSample);
+    });
+
+    test('- Can convert LSN to String', () {
+      final lsn = LSN(_lsnIntegerSample);
+
+      expect(lsn.toString(), _lsnStringSample);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds support for Streaming Replication Protocol. 

The following repository contains an example usage: [postgresql-dart-replication-example](https://github.com/osaxma/postgresql-dart-replication-example). While the protocol is intended for creating database replicas, the Logical Replication can be used to listen to changes in the database (e.g. inserts, updates, and deletes). 

A summary of additions and changes:
- Added VS Code IDE files to `.gitignore`
- Raised the min sdk to 2.17.0 to use enhanced enums 
  - I assume this could be treated as the only possible breaking change.
- Added `querySimple` method
  -  Similar to `execute`, but it'll return whatever data the server gives. 
  - This is necessary since in streaming replication mode, the extended query protocol cannot be used. On the other hand, `execute` does not return any data. `querySimple` was introduced to avoid breaking the existing API and to allow querying the database in Replication Mode which is necessary (i.e. executing `IDENTIFY_SYSTEM;` and retrieving the system info data) 
- Added `addMessage` method to PostgreSQLConnection
  - I assumed since the socket is already publicly exposed, there's no harm of adding this method. 
- Added `Stream<ServerMessage> messages` to PostgreSQLConnection
  - Since `socket` is a single listener stream, there's no way to listen to server messages after opening the connection.
  - The implementation is similar to `notifications` except that it'll pass all messages to any listeners. 
  - In combination with `addMessage`, the user can take over the communication with the server. 
  - This is necessary to respond to server messages in replication mode as the connection will always be in a busy state (i.e. after running `START_REPLICATION`)
- Added new messages types 
  - New: `shared_messages.dart` and `logical_replication_messages.dart`
  - Also added few new messages to `client_messages.dart` and `server_messages.dart`
  - I feel all these messages files could be grouped in `messages` folder but I left that for review.
- Modified `MessageFramer.addBytes` to handle new message types and special cases 
  -  tests were added as well 
- Fixed a parsing issue in `CommandComplete` 
  - When executing `IDENTIFY_SYSTEM;`, the `SYSTEM` was parsed as the affected row integer 
  - Replaced the RegExp for better handling (only looks for digits at the end of the string)


I believe these were the major additions with few changes. 

--- 

About testing:
I added a test for `logicl_replication_test.dart` -- the test might need to be disabled for CI since the test restarts the docker container (necessary after`ALTER SYSTEM`) which could make any concurrent tests fail. Though I wanted to see how the CI reacts first. 

I also had difficulty running the tests locally (before adding the test mentioned above). Many tests throw ConnectionError when ran concurrently but when I ran them individually, they pass (had to start docker container manually for those that don't call `usePostgresDocker`). Also, all the SSL tests failed. 

I'm not sure if there's something that I'm missing on how I should run the tests.
