### PR TITLE
[Streaming Replication - 1st] Introduce new methods and getter to  PostgreSQLConnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ doc/api/
 *.iml
 *.ipr
 *.iws
+
+# VS Code IDE
+.vscode/

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -192,6 +192,19 @@ class PostgreSQLConnection extends Object
   /// After the returned [Future] completes, this connection can no longer be used to execute queries. Any queries in progress or queued are cancelled.
   Future close() => _close();
 
+  /// Adds a Client Message to the existing connection
+  ///
+  /// This is a low level API and the message must follow the protocol of this
+  /// connection. It's the responsiblity of the caller to ensure this message
+  /// does not interfere with any running queries or transactions.
+  void addMessage(ClientMessage message) {
+    if (isClosed) {
+      throw PostgreSQLException(
+          'Attempting to add a message, but connection is not open.');
+    }
+    _socket!.add(message.asBytes());
+  }
+
   /// Executes a series of queries inside a transaction on this connection.
   ///
   /// Queries executed inside [queryBlock] will be grouped together in a transaction. The return value of the [queryBlock]

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -205,7 +205,7 @@ class _PostgreSQLConnectionStateIdle extends _PostgreSQLConnectionState {
 
   _PostgreSQLConnectionState processQuery(Query<dynamic> q) {
     try {
-      if (q.onlyReturnAffectedRowCount) {
+      if (q.onlyReturnAffectedRowCount || q.useSendSimple) {
         q.sendSimple(connection!._socket!);
         return _PostgreSQLConnectionStateBusy(q);
       }
@@ -333,7 +333,7 @@ class _PostgreSQLConnectionStateReadyInTransaction
 
   _PostgreSQLConnectionState processQuery(Query<dynamic> q) {
     try {
-      if (q.onlyReturnAffectedRowCount) {
+      if (q.onlyReturnAffectedRowCount || q.useSendSimple) {
         q.sendSimple(connection!._socket!);
         return _PostgreSQLConnectionStateBusy(q);
       }

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -29,10 +29,31 @@ abstract class PostgreSQLExecutionContext {
   /// By default, instances of this class will reuse queries. This allows significantly more efficient transport to and from the database. You do not have to do
   /// anything to opt in to this behavior, this connection will track the necessary information required to reuse queries without intervention. (The [fmtString] is
   /// the unique identifier to look up reuse information.) You can disable reuse by passing false for [allowReuse].
+  /// 
+  /// [useSimpleQueryProtocol] indicates that the query will be executed using 
+  /// the [Simple Query Protocol][]. This is similar to runing [execute] but 
+  /// instead of receiving the `affectedRowCount` only, this method will return
+  /// [PostgreSQLResult] which contains `affectedRowCount` in addition to any 
+  /// data returned by the executed statement. 
+  /// 
+  /// It's important to understand that when [useSimpleQueryProtocol] is `true`,
+  /// all values will be of type [String] even if they have different type in the
+  /// database. For instance, the value of an `int4` column will be returned as
+  /// a [String] instead of an [int].
+  ///
+  /// Setting [useSimpleQueryProtocol] to `true` is mainly useful for when the 
+  /// connection is established using the Streaming Replication Protocol. When 
+  /// the connection is in replication mode, the default Extended Query Protocol
+  /// cannot be used as the database will throw an error and drop the connection. 
+  /// In other words, only the Simple Query Protocol can be used with Streaming 
+  /// Replication Protocol.
+  /// 
+  /// [Simple Query Protocol]: https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.4
   Future<PostgreSQLResult> query(String fmtString,
       {Map<String, dynamic>? substitutionValues,
       bool? allowReuse,
-      int? timeoutInSeconds});
+      int? timeoutInSeconds,
+      bool? useSimpleQueryProtocol});
 
   /// Executes a query on this context.
   ///
@@ -86,29 +107,6 @@ abstract class PostgreSQLExecutionContext {
       bool? allowReuse,
       int? timeoutInSeconds});
 
-  /// Executes a simple query on this context.
-  ///
-  /// This method is similar to [execute] except that it'll return all the data.
-  /// That is, when the query result contains data, the method will return a
-  /// [PostgreSQLResult]. If the query does not return data, then the affected row
-  /// count is returned as [int].
-  ///
-  /// Unlike [query], this method uses the Simple Query Protocol. that means,
-  /// all values will be of type [String] even if they have different type in the
-  /// database. For instance, the value of an `int4` column will be returned as
-  /// a [String] instead of an [int].
-  ///
-  /// This method uses the least efficient and less secure command for executing
-  /// queries in the PostgreSQL protocol; [query] is preferred for queries that
-  /// will be executed more than once, will contain user input, or return rows.
-  ///
-  /// This method is useful during the Streaming Replication Mode since the
-  /// Extended Query Protocol (i.e. [query] and [mappedResultsQuery]) cannot be
-  /// used in a replication connection. In such case, when the result of a query
-  /// is necessary to be retrieved, this method can be used instead of [execute].
-  Future<dynamic> simpleQuery(String fmtString,
-      {Map<String, dynamic>? substitutionValues = const {},
-      int? timeoutInSeconds});
 }
 
 /// A description of a column.

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -85,6 +85,30 @@ abstract class PostgreSQLExecutionContext {
       {Map<String, dynamic>? substitutionValues,
       bool? allowReuse,
       int? timeoutInSeconds});
+
+  /// Executes a simple query on this context.
+  ///
+  /// This method is similar to [execute] except that it'll return all the data.
+  /// That is, when the query result contains data, the method will return a
+  /// [PostgreSQLResult]. If the query does not return data, then the affected row
+  /// count is returned as [int].
+  ///
+  /// Unlike [query], this method uses the Simple Query Protocol. that means,
+  /// all values will be of type [String] even if they have different type in the
+  /// database. For instance, the value of an `int4` column will be returned as
+  /// a [String] instead of an [int].
+  ///
+  /// This method uses the least efficient and less secure command for executing
+  /// queries in the PostgreSQL protocol; [query] is preferred for queries that
+  /// will be executed more than once, will contain user input, or return rows.
+  ///
+  /// This method is useful during the Streaming Replication Mode since the
+  /// Extended Query Protocol (i.e. [query] and [mappedResultsQuery]) cannot be
+  /// used in a replication connection. In such case, when the result of a query
+  /// is necessary to be retrieved, this method can be used instead of [execute].
+  Future<dynamic> simpleQuery(String fmtString,
+      {Map<String, dynamic>? substitutionValues = const {},
+      int? timeoutInSeconds});
 }
 
 /// A description of a column.

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -21,9 +21,12 @@ class Query<T> {
     this.transaction,
     this.queryStackTrace, {
     this.onlyReturnAffectedRowCount = false,
+    this.useSendSimple = false,
   });
 
   final bool onlyReturnAffectedRowCount;
+
+  final bool useSendSimple;
 
   String? statementIdentifier;
 
@@ -139,6 +142,21 @@ class Query<T> {
 
   void addRow(List<Uint8List?> rawRowData) {
     if (onlyReturnAffectedRowCount || fieldDescriptions == null) {
+      return;
+    }
+
+    // Simple queries do not follow the same binary codecs. All values will be
+    // returned as strings.
+    //
+    // For instance, a column can be defined as `int4` which is expected to be
+    // 4 bytes long (i.e. decoded using bytes.getUint32) but when using simple
+    // query (i.e. sendSimple), the value will be returned as a string.
+    //
+    // See response to:
+    // https://postgresql.org/message-id/17325-f45d35e03971e979%40postgresql.org
+    if (useSendSimple) {
+      final data = rawRowData.map((e) => utf8.decode(e!));
+      rows.add(data.toList());
       return;
     }
 

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -152,8 +152,9 @@ class Query<T> {
     // 4 bytes long (i.e. decoded using bytes.getUint32) but when using simple
     // query (i.e. sendSimple), the value will be returned as a string.
     //
-    // See response to:
-    // https://postgresql.org/message-id/17325-f45d35e03971e979%40postgresql.org
+    // See Simple Query section in Protocol Message Flow:
+    // "In simple Query mode, the format of retrieved values is always text"
+    //  https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.4
     if (useSendSimple) {
       final data = rawRowData.map((e) => utf8.decode(e!));
       rows.add(data.toList());


### PR DESCRIPTION
This PR adds functionality that's necessary for Streaming Replication.

The following will be the additions to `PostgreSQLConnection`:

- `querySimple` method
  -  Similar to `execute`, but it'll return whatever data the server gives. 
  - This is necessary since in streaming replication mode, the extended query protocol cannot be used. On the other hand, `execute` does not return any data. `querySimple` was introduced to avoid breaking the existing API and to allow querying the database in Replication Mode which is necessary (i.e. executing `IDENTIFY_SYSTEM;` and retrieving the system info data) 

- `addMessage` method
  - I assumed since the socket is already publicly exposed, there's no harm of adding this method. 

- `Stream<ServerMessage> messages` 
  - Since `socket` is a single listener stream, there's no way to listen to server messages after opening the connection.
  - The implementation is similar to `notifications` except that it'll pass all messages to any listeners. 
  - In combination with `addMessage`, the user can take over the communication with the server. 
  - This is necessary to respond to server messages in replication mode as the connection will always be in a busy state (i.e. after running `START_REPLICATION`)



p.s.  I also added `.vscode` in `.gitignore`. 