### PR TITLE
[Streaming Replication - 3rd] Add LSN type and time conversion to and from ms-since-Y2K

### DIFF
--- a/lib/src/time_converters.dart
+++ b/lib/src/time_converters.dart
@@ -1,0 +1,12 @@
+const _microsecFromUnixEpochToY2K = 946684800 * 1000000;
+
+DateTime dateTimeFromMicrosecondsSinceY2k(int microSecondsSinceY2K) {
+  final microsecSinceUnixEpoch =
+      _microsecFromUnixEpochToY2K + microSecondsSinceY2K;
+  return DateTime.fromMicrosecondsSinceEpoch(microsecSinceUnixEpoch, isUtc: true);
+}
+
+int dateTimeToMicrosecondsSinceY2k(DateTime time) {
+  final microsecSinceUnixEpoch = time.toUtc().microsecondsSinceEpoch;
+  return microsecSinceUnixEpoch - _microsecFromUnixEpochToY2K;
+}

--- a/lib/src/time_converters.dart
+++ b/lib/src/time_converters.dart
@@ -1,9 +1,11 @@
-const _microsecFromUnixEpochToY2K = 946684800 * 1000000;
+final _microsecFromUnixEpochToY2K =
+    DateTime.utc(2000, 1, 1).microsecondsSinceEpoch;
 
 DateTime dateTimeFromMicrosecondsSinceY2k(int microSecondsSinceY2K) {
   final microsecSinceUnixEpoch =
       _microsecFromUnixEpochToY2K + microSecondsSinceY2K;
-  return DateTime.fromMicrosecondsSinceEpoch(microsecSinceUnixEpoch, isUtc: true);
+  return DateTime.fromMicrosecondsSinceEpoch(microsecSinceUnixEpoch,
+      isUtc: true);
 }
 
 int dateTimeToMicrosecondsSinceY2k(DateTime time) {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -103,3 +103,54 @@ enum PostgreSQLDataType {
   /// Must be a [List] of encodable objects
   jsonbArray,
 }
+
+/// LSN is a PostgreSQL Log Sequence Number.
+///
+/// For more details, see: https://www.postgresql.org/docs/current/datatype-pg-lsn.html
+class LSN {
+  final int value;
+
+  /// Construct an LSN from a 64-bit integer.
+  LSN(this.value);
+
+  /// Construct an LSN from XXX/XXX format used by PostgreSQL
+  LSN.fromString(String string) : value = _parseLSNString(string);
+
+  /// Formats the LSN value into the XXX/XXX format which is the text format
+  /// used by PostgreSQL.
+  @override
+  String toString() {
+    return '${(value >> 32).toRadixString(16).toUpperCase()}/${value.toUnsigned(32).toRadixString(16).toUpperCase()}';
+  }
+
+  static int _parseLSNString(String string) {
+    int upperhalf;
+    int lowerhalf;
+    final halves = string.split('/');
+    if (halves.length != 2) {
+      throw Exception('Invalid LSN String was given ($string)');
+    }
+    upperhalf = int.parse(halves[0], radix: 16) << 32;
+    lowerhalf = int.parse(halves[1], radix: 16);
+
+    return (upperhalf + lowerhalf).toInt();
+  }
+
+  LSN operator +(LSN other) {
+    return LSN(value + other.value);
+  }
+
+  LSN operator -(LSN other) {
+    return LSN(value + other.value);
+  }
+
+  @override
+  bool operator ==(covariant LSN other) {
+    if (identical(this, other)) return true;
+
+    return other.value == value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+}

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -124,14 +124,12 @@ class LSN {
   }
 
   static int _parseLSNString(String string) {
-    int upperhalf;
-    int lowerhalf;
     final halves = string.split('/');
     if (halves.length != 2) {
-      throw Exception('Invalid LSN String was given ($string)');
+      throw FormatException('Invalid LSN String was given ($string)');
     }
-    upperhalf = int.parse(halves[0], radix: 16) << 32;
-    lowerhalf = int.parse(halves[1], radix: 16);
+    final upperhalf = int.parse(halves[0], radix: 16) << 32;
+    final lowerhalf = int.parse(halves[1], radix: 16);
 
     return (upperhalf + lowerhalf).toInt();
   }

--- a/test/time_converter_test.dart
+++ b/test/time_converter_test.dart
@@ -1,0 +1,22 @@
+import 'package:postgres/src/time_converters.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('test time conversion from pg to dart and vice versa', () {
+    test('pgTimeToDateTime produces correct DateTime', () {
+      final timeFromPg = dateTimeFromMicrosecondsSinceY2k(0);
+
+      expect(timeFromPg.year, 2000);
+      expect(timeFromPg.month, 1);
+      expect(timeFromPg.day, 1);
+    });
+
+    test('dateTimeToPgTime produces correct microseconds since 2000-01-01', () {
+      // final timeFromPg = pgTimeToDateTime(0);
+      final dateTime = DateTime.utc(2000, 1, 1);
+      final pgTime = dateTimeToMicrosecondsSinceY2k(dateTime);
+      expect(pgTime, 0);
+    });
+  });
+}

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -1,0 +1,25 @@
+import 'package:postgres/postgres.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+// These two numbers are equal but in different formats
+// 
+// see: https://www.postgresql.org/docs/current/datatype-pg-lsn.html
+const _lsnStringSample = '16/B374D848';
+const _lsnIntegerSample = 97500059720;
+
+void main() {
+  group('LSN type', () {
+    test('- Can parse LSN String', () {
+      final lsn = LSN.fromString(_lsnStringSample);
+
+      expect(lsn.value, _lsnIntegerSample);
+    });
+
+    test('- Can convert LSN to String', () {
+      final lsn = LSN(_lsnIntegerSample);
+
+      expect(lsn.toString(), _lsnStringSample);
+    });
+  });
+}

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -2,24 +2,18 @@ import 'package:postgres/postgres.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
-// These two numbers are equal but in different formats
-// 
-// see: https://www.postgresql.org/docs/current/datatype-pg-lsn.html
-const _lsnStringSample = '16/B374D848';
-const _lsnIntegerSample = 97500059720;
-
 void main() {
   group('LSN type', () {
     test('- Can parse LSN String', () {
-      final lsn = LSN.fromString(_lsnStringSample);
-
-      expect(lsn.value, _lsnIntegerSample);
+      // These two numbers are equal but in different formats
+      // see: https://www.postgresql.org/docs/current/datatype-pg-lsn.html
+      final lsn = LSN.fromString('16/B374D848');
+      expect(lsn.value, 97500059720);
     });
 
     test('- Can convert LSN to String', () {
-      final lsn = LSN(_lsnIntegerSample);
-
-      expect(lsn.toString(), _lsnStringSample);
+      final lsn = LSN(97500059720);
+      expect(lsn.toString(), '16/B374D848');
     });
   });
 }


### PR DESCRIPTION
- Adds Log Sequence Number type -- used widely by the Streaming Replication Messages 
- Adds conversion form and to microseconds since 2000-01-01 (the baseline time used by PostgreSQL in replication messages). 