### PR TITLE
[Streaming Replication 4th] Raise the min sdk version to support enhanced enums

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.4.6
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   buffer: ^1.1.0


### PR DESCRIPTION
Closes: #54 

I think it's better to have this on its own PR. Though, if this is accepted, I'm not sure if bumping the version should occur here or in a separate PR after all PRs are completed. 

By the way, I cannot add more PRs for now as the rest of the changes requires the functionality of this PR as well as the other three that were submitted before this one. 

I was thinking to add the version and CHANGELOG in a separate PR so it's easier to merge everything. Otherwise I'd have to rebase each PR after the other. 