### PR TITLE
[Streaming Replication 5th] add connection configuration for Streaming Replication Protocol

### DIFF
--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -106,14 +106,25 @@ class PostgreSQLConnection extends Object
   ///
   /// When the value is set to either [ReplicationMode.physical] or [ReplicationMode.logical],
   /// the query protocol will no longer work as the connection will be switched to a replication
-  /// connection. In other words, using [query] or [mappedResultsQuery] will throw an error. Use
-  /// [execute] for executing statements while in replication mode.
+  /// connection. In other words, using the default [query] or [mappedResultsQuery] will cause
+  /// the database to throw an error and drop the connection.
+  /// 
+  /// Use [query] `useSimpleQueryProtocol` set to `true` or [execute] for executing statements 
+  /// while in replication mode.
+  /// 
+  /// For more info, see [Streaming Replication Protocol]
+  /// 
+  /// [Streaming Replication Protocol]: https://www.postgresql.org/docs/current/protocol-replication.html
   final ReplicationMode replicationMode;
 
   /// The Logical Decoding Output for streaming replication mode
   ///
-  /// The default value is [LogicalDecodingPlugin.pgoutput]. This value is only used
-  /// when [replicationMode] is not equal to [ReplicationMode.none].
+  /// The default value is [LogicalDecodingPlugin.pgoutput]. To use [LogicalDecodingPlugin.wal2json],
+  /// the [wal2json] plugin must be installed in the database. 
+  /// 
+  /// [logicalDecodingPlugin] is only used when [replicationMode] is not equal to [ReplicationMode.none].
+  /// 
+  /// [wal2json]: https://github.com/eulerto/wal2json
   final LogicalDecodingPlugin logicalDecodingPlugin;
 
   /// Stream of notification from the database.

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -54,7 +54,6 @@ class PostgreSQLConnection extends Object
     this.isUnixSocket = false,
     this.allowClearTextPassword = false,
     this.replicationMode = ReplicationMode.none,
-    this.logicalDecodingPlugin = LogicalDecodingPlugin.pgoutput,
   }) {
     _connectionState = _PostgreSQLConnectionStateClosed();
     _connectionState.connection = this;
@@ -108,24 +107,14 @@ class PostgreSQLConnection extends Object
   /// the query protocol will no longer work as the connection will be switched to a replication
   /// connection. In other words, using the default [query] or [mappedResultsQuery] will cause
   /// the database to throw an error and drop the connection.
-  /// 
-  /// Use [query] `useSimpleQueryProtocol` set to `true` or [execute] for executing statements 
+  ///
+  /// Use [query] `useSimpleQueryProtocol` set to `true` or [execute] for executing statements
   /// while in replication mode.
-  /// 
+  ///
   /// For more info, see [Streaming Replication Protocol]
-  /// 
+  ///
   /// [Streaming Replication Protocol]: https://www.postgresql.org/docs/current/protocol-replication.html
   final ReplicationMode replicationMode;
-
-  /// The Logical Decoding Output for streaming replication mode
-  ///
-  /// The default value is [LogicalDecodingPlugin.pgoutput]. To use [LogicalDecodingPlugin.wal2json],
-  /// the [wal2json] plugin must be installed in the database. 
-  /// 
-  /// [logicalDecodingPlugin] is only used when [replicationMode] is not equal to [ReplicationMode.none].
-  /// 
-  /// [wal2json]: https://github.com/eulerto/wal2json
-  final LogicalDecodingPlugin logicalDecodingPlugin;
 
   /// Stream of notification from the database.
   ///
@@ -593,7 +582,7 @@ abstract class _PostgreSQLExecutionContextMixin
       StackTrace.current,
       useSendSimple: true,
       // TODO: this could be removed from Query since useSendSimple covers the
-      //       functionality. 
+      //       functionality.
       onlyReturnAffectedRowCount: onlyReturnAffectedRows,
     );
 

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -14,6 +14,7 @@ import 'message_window.dart';
 import 'query.dart';
 import 'query_cache.dart';
 import 'query_queue.dart';
+import 'replication.dart';
 import 'server_messages.dart';
 
 part 'connection_fsm.dart';
@@ -52,6 +53,8 @@ class PostgreSQLConnection extends Object
     this.useSSL = false,
     this.isUnixSocket = false,
     this.allowClearTextPassword = false,
+    this.replicationMode = ReplicationMode.none,
+    this.logicalDecodingPlugin = LogicalDecodingPlugin.pgoutput,
   }) {
     _connectionState = _PostgreSQLConnectionStateClosed();
     _connectionState.connection = this;
@@ -98,6 +101,20 @@ class PostgreSQLConnection extends Object
 
   /// If true, allows password in clear text for authentication.
   final bool allowClearTextPassword;
+
+  /// The replication mode for connecting in streaming replication mode.
+  ///
+  /// When the value is set to either [ReplicationMode.physical] or [ReplicationMode.logical],
+  /// the query protocol will no longer work as the connection will be switched to a replication
+  /// connection. In other words, using [query] or [mappedResultsQuery] will throw an error. Use
+  /// [execute] for executing statements while in replication mode.
+  final ReplicationMode replicationMode;
+
+  /// The Logical Decoding Output for streaming replication mode
+  ///
+  /// The default value is [LogicalDecodingPlugin.pgoutput]. This value is only used
+  /// when [replicationMode] is not equal to [ReplicationMode.none].
+  final LogicalDecodingPlugin logicalDecodingPlugin;
 
   /// Stream of notification from the database.
   ///

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -49,7 +49,8 @@ class _PostgreSQLConnectionStateSocketConnected
   _PostgreSQLConnectionState onEnter() {
     final startupMessage = StartupMessage(
         connection!.databaseName, connection!.timeZone,
-        username: connection!.username);
+        username: connection!.username,
+        replication: connection!.replicationMode);
 
     connection!._socket!.add(startupMessage.asBytes());
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -21,4 +21,18 @@ class UTF8ByteConstants {
   ];
   static const utf8 = <int>[85, 84, 70, 56, 0];
   static const timeZone = <int>[84, 105, 109, 101, 90, 111, 110, 101, 0];
+  static const replication = <int>[
+    114,
+    101,
+    112,
+    108,
+    105,
+    99,
+    97,
+    116,
+    105,
+    111,
+    110,
+    0
+  ];
 }

--- a/lib/src/replication.dart
+++ b/lib/src/replication.dart
@@ -1,0 +1,39 @@
+// TODO: these types could move to a common "connection_config.dart" file
+
+/// Streaming Replication Protocol Options
+///
+/// [physical] or [logical] are used to start the connection a streaming
+/// replication mode.
+///
+/// See [Protocol Replication][] for more details.
+///
+/// [Protocol Replication]: https://www.postgresql.org/docs/current/protocol-replication.html
+enum ReplicationMode {
+  physical('true'),
+  logical('database'),
+  none('false');
+
+  final String value;
+
+  const ReplicationMode(this.value);
+}
+
+/// The Logical Decoding Output Plugins For Streaming Replication
+///
+/// [pgoutput] is the standard logical decoding plugin that is built in
+/// PostgreSQL since version 10.
+///
+/// [wal2json] is a popular output plugin for logical decoding. The extension
+/// must be available on the database when using this output option. When using
+/// [wal2json] plugin, the following are some limitations:
+/// - the plug-in does not emit events for tables without primary keys
+/// - the plug-in does not support special values (NaN or infinity) for floating
+///   point types
+///
+/// For more info, see [wal2json repo][].
+///
+/// [wal2json repo]: https://github.com/eulerto/wal2json
+enum LogicalDecodingPlugin {
+  pgoutput,
+  wal2json,
+}

--- a/lib/src/replication.dart
+++ b/lib/src/replication.dart
@@ -17,23 +17,3 @@ enum ReplicationMode {
 
   const ReplicationMode(this.value);
 }
-
-/// The Logical Decoding Output Plugins For Streaming Replication
-///
-/// [pgoutput] is the standard logical decoding plugin that is built in
-/// PostgreSQL since version 10.
-///
-/// [wal2json] is a popular output plugin for logical decoding. The extension
-/// must be available on the database when using this output option. When using
-/// [wal2json] plugin, the following are some limitations:
-/// - the plug-in does not emit events for tables without primary keys
-/// - the plug-in does not support special values (NaN or infinity) for floating
-///   point types
-///
-/// For more info, see [wal2json repo][].
-///
-/// [wal2json repo]: https://github.com/eulerto/wal2json
-enum LogicalDecodingPlugin {
-  pgoutput,
-  wal2json,
-}

--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -81,7 +81,8 @@ void main() {
           )));
     });
 
-    test('Connect with ReplicationMode.none', () async {
+    test('Connecting with ReplicationMode.none uses Extended Query Protocol',
+        () async {
       final conn = PostgreSQLConnection(
         'localhost',
         5432,
@@ -92,8 +93,9 @@ void main() {
       );
 
       await conn.open();
-
-      expect(await conn.execute('select 1'), equals(1));
+      // This would throw for ReplicationMode.logical or ReplicationMode.physical
+      final result = await conn.query('select 1');
+      expect(result.affectedRowCount, equals(1));
     });
 
     test('Connect with logical ReplicationMode.logical', () async {

--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'dart:mirrors';
 
 import 'package:postgres/postgres.dart';
+import 'package:postgres/src/replication.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';
@@ -79,6 +80,70 @@ void main() {
                 'Attempting to reopen a closed connection. Create a instance instead.'),
           )));
     });
+
+    test('Connect with ReplicationMode.none', () async {
+      final conn = PostgreSQLConnection(
+        'localhost',
+        5432,
+        'dart_test',
+        username: 'dart',
+        password: 'dart',
+        replicationMode: ReplicationMode.none,
+      );
+
+      await conn.open();
+
+      expect(await conn.execute('select 1'), equals(1));
+    });
+
+    test('Connect with logical ReplicationMode.logical', () async {
+      final conn = PostgreSQLConnection(
+        'localhost',
+        5432,
+        'dart_test',
+        username: 'dart',
+        password: 'dart',
+        replicationMode: ReplicationMode.logical,
+      );
+
+      await conn.open();
+
+      expect(await conn.execute('select 1'), equals(1));
+    });
+
+    test('IDENTIFY_SYSTEM returns system information', () async {
+      final conn = PostgreSQLConnection(
+        'localhost',
+        5432,
+        'dart_test',
+        username: 'dart',
+        password: 'dart',
+        replicationMode: ReplicationMode.logical,
+      );
+
+      await conn.open();
+
+      // This query can only be executed in Streaming Replication Protocol
+      // In addition, it can only be executed using Simple Query Protocol:
+      // "In either physical replication or logical replication walsender mode,
+      //  only the simple query protocol can be used."
+      // source and more info:
+      // https://www.postgresql.org/docs/current/protocol-replication.html
+      final result = await conn.query(
+        'IDENTIFY_SYSTEM;',
+        useSimpleQueryProtocol: true,
+      );
+
+      expect(result.length, 1);
+      expect(result.columnDescriptions.length, 4);
+      expect(result.columnDescriptions[0].columnName, 'systemid');
+      expect(result.columnDescriptions[1].columnName, 'timeline');
+      expect(result.columnDescriptions[2].columnName, 'xlogpos');
+      expect(result.columnDescriptions[3].columnName, 'dbname');
+    });
+
+    // TODO: add test for ReplicationMode.physical which requires tuning some
+    //       settings in the pg_hba.conf
   });
 
   // These tests are disabled, as we'd need to setup ci/pg_hba.conf into the CI


### PR DESCRIPTION
This change simply allows running `PostgreSQLConnection` in replication mode in the following manner:

```dart
  final conn = PostgreSQLConnection(
    'localhost',
    5432,
    'postgres',
    username: 'postgres',
    password: 'postgres',
    replicationMode: ReplicationMode.logical,
  );
```

Tests were added which shows the use of `useSimpleQueryProtocol` (turning that off will make the test fail)

---- 

