### PR TITLE
Add substitutionValues for useSimpleQueryProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.1
+- Use `substitutionValues` with `useSimpleQueryProtocol` [#62](https://github.com/isoos/postgresql-dart/pull/62) by [osaxma](https://github.com/osaxma)
+
 ## 2.5.0
 - Added Support for Streaming Replication Protocol which included the following changes:
   - Replication Mode Messages Handling. [#58](https://github.com/isoos/postgresql-dart/pull/58) by [osaxma](https://github.com/osaxma)

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -496,6 +496,7 @@ abstract class _PostgreSQLExecutionContextMixin
         fmtString,
         timeoutInSeconds: timeoutInSeconds,
         onlyReturnAffectedRows: false,
+        substitutionValues: substitutionValues,
       );
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 2.5.0
+version: 2.5.1
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:


### PR DESCRIPTION
`substitutionValues` was ignored for `useSimpleQueryProtocol` -- my bad. 