### PR TITLE
Update GitHub actions to run all tests 

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -15,22 +15,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_DB: dart_test
-          POSTGRES_PASSWORD: dart
-          POSTGRES_USER: dart
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - uses: actions/checkout@v2
 
@@ -51,8 +35,15 @@ jobs:
       - name: Analyze project source
         run: dart analyze
 
-      # Your project will need to have tests in test/ and a dependency on
-      # package:test for this step to succeed. Note that Flutter projects will
-      # want to change this to 'flutter test'.
+      # pre-pull the image so `usePostgresDocker` does not delay which may causes 
+      # tests to timeout
+      - name: pull latest postgres image
+        run: docker pull postgres:latest
+
+      # Run all tests with a concurency of "1" to allow each test to run independently. 
+      #   This is mainly to prevent `tearDownAll` in `usePostgresDocker` from stoping
+      #   the container while another test is using the container. In other words, each
+      #   test file will call `usePostgresDocker` for container setup and teardown and  
+      #   run its test in between. Using concurrency of "1" will ensure this behavior.   
       - name: Run tests
-        run: dart test
+        run: dart test -j 1

--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -146,7 +146,6 @@ void main() {
     //       settings in the pg_hba.conf
   });
 
-
   group('Connection lifecycle', () {
     late PostgreSQLConnection conn;
 

--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -97,19 +97,12 @@ void main() {
     });
 
     test('Connect with logical ReplicationMode.logical', () async {
-      // TODO: remove this once `replication` user created on CI
-      late final String username, password;
-      if (Platform.environment.containsKey('GITHUB_ACTION')) {
-        username = password = 'dart';
-      } else {
-        username = password = 'replication';
-      }
       final conn = PostgreSQLConnection(
         'localhost',
         5432,
         'dart_test',
-        username: username,
-        password: password,
+        username: 'replication',
+        password: 'replication',
         replicationMode: ReplicationMode.logical,
       );
 
@@ -119,19 +112,12 @@ void main() {
     });
 
     test('IDENTIFY_SYSTEM returns system information', () async {
-      // TODO: remove this once `replication` user created on CI
-      late final String username, password;
-      if (Platform.environment.containsKey('GITHUB_ACTION')) {
-        username = password = 'dart';
-      } else {
-        username = password = 'replication';
-      }
       final conn = PostgreSQLConnection(
         'localhost',
         5432,
         'dart_test',
-        username: username,
-        password: password,
+        username: 'replication',
+        password: 'replication',
         replicationMode: ReplicationMode.logical,
       );
 
@@ -160,15 +146,6 @@ void main() {
     //       settings in the pg_hba.conf
   });
 
-  // These tests are disabled, as we'd need to setup ci/pg_hba.conf into the CI
-  // postgres instance first.
-  // TODO: re-enable these tests after pg_hba.conf is used
-  if (Platform.environment.containsKey('GITHUB_ACTION')) {
-    test('NO CONNECTION TEST IS RUNNING.', () {
-      // no-op
-    });
-    return;
-  }
 
   group('Connection lifecycle', () {
     late PostgreSQLConnection conn;

--- a/test/docker.dart
+++ b/test/docker.dart
@@ -7,13 +7,8 @@ import 'package:test/test.dart';
 const _kContainerName = 'postgres-dart-test';
 
 void usePostgresDocker() {
-  bool isGithubAction() => Platform.environment.containsKey('GITHUB_ACTION');
 
   setUpAll(() async {
-    if (isGithubAction()) {
-      // Postgres already running
-      return;
-    }
 
     final isRunning = await _isPostgresContainerRunning();
     if (isRunning) {
@@ -67,9 +62,6 @@ void usePostgresDocker() {
   });
 
   tearDownAll(() async {
-    if (isGithubAction()) {
-      return;
-    }
     await Process.run('docker', ['stop', _kContainerName]);
   });
 }

--- a/test/docker.dart
+++ b/test/docker.dart
@@ -7,9 +7,7 @@ import 'package:test/test.dart';
 const _kContainerName = 'postgres-dart-test';
 
 void usePostgresDocker() {
-
   setUpAll(() async {
-
     final isRunning = await _isPostgresContainerRunning();
     if (isRunning) {
       return;
@@ -78,10 +76,9 @@ Future<bool> _isPostgresContainerRunning() async {
       .contains(_kContainerName);
 }
 
-
-// This setup supports old and new test 
+// This setup supports old and new test
 // This is setup is the same as the one from the old travis ci except for the
-// replication user which is a new addition. 
+// replication user which is a new addition.
 final _setupDatabaseStatements = <String>[
   // create testing database
   'create database dart_test;',

--- a/test/logical_replication_test.dart
+++ b/test/logical_replication_test.dart
@@ -8,7 +8,6 @@ import 'package:test/scaffolding.dart';
 import 'docker.dart';
 
 void main() {
-
   usePostgresDocker();
 
   // NOTES:
@@ -66,8 +65,7 @@ void main() {
 
       // create publication
       final publicationName = 'test_publication';
-      await changesConn
-          .execute('DROP PUBLICATION IF EXISTS $publicationName;');
+      await changesConn.execute('DROP PUBLICATION IF EXISTS $publicationName;');
       await changesConn.execute(
         'CREATE PUBLICATION $publicationName FOR TABLE $changesTable, $truncateTable;',
       );

--- a/test/logical_replication_test.dart
+++ b/test/logical_replication_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:postgres/messages.dart';
 import 'package:postgres/postgres.dart';
@@ -9,19 +8,6 @@ import 'package:test/scaffolding.dart';
 import 'docker.dart';
 
 void main() {
-  // Running these tests on the CI will not work as there is no way to pass
-  // image arguments to the `services.postgres` container of github actions.
-  //
-  // TODO: Find a solution to spin up a postgres container where one can enable
-  //       the replication configuration before spinning up the container either
-  //       by passing image arguments or restarting the container after altering
-  //       the database configurations (required for replication configs).
-  if (Platform.environment.containsKey('GITHUB_ACTION')) {
-    test('NO LOGICAL REPLICATION TESTS ARE RUNNING.', () {
-      // no-op
-    });
-    return;
-  }
 
   usePostgresDocker();
 

--- a/test/non_ascii_connection_strings_test.dart
+++ b/test/non_ascii_connection_strings_test.dart
@@ -7,7 +7,6 @@ import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
 void main() {
-
   final user = 'abc@def';
   final password = 'pöstgrēs_üšęr_pæsswœêrd';
   final db = 'postgres';

--- a/test/non_ascii_connection_strings_test.dart
+++ b/test/non_ascii_connection_strings_test.dart
@@ -7,14 +7,7 @@ import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
 void main() {
-  /// This cannot be run on CI as each test requires different pg_hba.conf
-  /// to be mounted to the container. 
-  if (Platform.environment.containsKey('GITHUB_ACTION')) {
-    test('NO NON-ASCII CONNECTION STRINGS TESTS ARE RUNNING.', () {
-      // no-op
-    });
-    return;
-  }
+
   final user = 'abc@def';
   final password = 'pöstgrēs_üšęr_pæsswœêrd';
   final db = 'postgres';

--- a/test/notification_test.dart
+++ b/test/notification_test.dart
@@ -6,7 +6,6 @@ import 'package:test/test.dart';
 import 'docker.dart';
 
 void main() {
-
   usePostgresDocker();
 
   group('Successful notifications', () {


### PR DESCRIPTION
This should allow running all tests (34 tests that were not running on Github before the change). 

I avoided using tags because it'll just complicate the process for no added benefits. I think with concurrency of "1", the tests will run for extra 30~60 seconds than it was before; on the other hand, the setup is straightforward in both the test files and the workflow file.  

p.s. I didn't know that ubuntu comes with docker installed so the change was easier than I thought. 