### PR TITLE
No password non trusted users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.2
+- Connecting without a passwort for non-trusted users throws an exception instead of timing out [#68](https://github.com/isoos/postgresql-dart/pull/68) by [osaxma](https://github.com/osaxma).
+
 ## 2.5.1
 - Use `substitutionValues` with `useSimpleQueryProtocol` [#62](https://github.com/isoos/postgresql-dart/pull/62) by [osaxma](https://github.com/osaxma)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.5.2
-- Connecting without a passwort for non-trusted users throws an exception instead of timing out [#68](https://github.com/isoos/postgresql-dart/pull/68) by [osaxma](https://github.com/osaxma).
+- Connecting without a password for non-trusted users throws an exception instead of timing out [#68](https://github.com/isoos/postgresql-dart/pull/68) by [osaxma](https://github.com/osaxma).
 
 ## 2.5.1
 - Use `substitutionValues` with `useSimpleQueryProtocol` [#62](https://github.com/isoos/postgresql-dart/pull/62) by [osaxma](https://github.com/osaxma)

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -147,10 +147,10 @@ class _PostgreSQLConnectionStateAuthenticating
           try {
             _authenticator.onMessage(message);
             return this;
-          } catch (e) {
+          } catch (e, st) {
             // an exception occurred in the authenticator that isn't a PostgreSQL
             // Exception (e.g. `Null check operator used on a null value`)
-            completer.completeError(Exception(e));
+            completer.completeError(e, st);
             break;
           }
       }

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -108,6 +108,14 @@ class _PostgreSQLConnectionStateAuthenticating
         case AuthenticationMessage.KindOK:
           return _PostgreSQLConnectionStateAuthenticated(completer);
         case AuthenticationMessage.KindMD5Password:
+          // this means the server is requesting an md5 challenge
+          // so the password must not be null
+          if (connection!.password == null) {
+            completer.completeError(PostgreSQLException(
+              'Password is required for "${connection!.username}" user to establish a connection',
+            ));
+            break;
+          }
           _authenticator =
               createAuthenticator(connection!, AuthenticationScheme.MD5);
           continue authMsg;
@@ -122,14 +130,29 @@ class _PostgreSQLConnectionStateAuthenticating
             break;
           }
         case AuthenticationMessage.KindSASL:
+          // this means the server is requesting a scram-sha-256 challenge
+          // so the password must not be null
+          if (connection!.password == null) {
+            completer.completeError(PostgreSQLException(
+              'Password is required for "${connection!.username}" user to establish a connection',
+            ));
+            break;
+          }
           _authenticator = createAuthenticator(
               connection!, AuthenticationScheme.SCRAM_SHA_256);
           continue authMsg;
         authMsg:
         case AuthenticationMessage.KindSASLContinue:
         case AuthenticationMessage.KindSASLFinal:
-          _authenticator.onMessage(message);
-          return this;
+          try {
+            _authenticator.onMessage(message);
+            return this;
+          } catch (e) {
+            // an exception occurred in the authenticator that isn't a PostgreSQL
+            // Exception (e.g. `Null check operator used on a null value`)
+            completer.completeError(Exception(e));
+            break;
+          }
       }
 
       completer.completeError(PostgreSQLException(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 2.5.1
+version: 2.5.2
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:

--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -185,6 +185,20 @@ void main() {
       expect(await conn.execute('select 1'), equals(1));
     });
 
+    test('Connect with no auth throws for non trusted users', () async {
+      conn = PostgreSQLConnection('localhost', 5432, 'dart_test',
+          username: 'dart');
+      try {
+        await conn.open();
+      } catch (e) {
+        expect(e, isA<PostgreSQLException>());
+        expect(
+          (e as PostgreSQLException).message,
+          contains('Password is required'),
+        );
+      }
+    });
+
     test('SSL Connect with no auth required', () async {
       conn = PostgreSQLConnection('localhost', 5432, 'dart_test',
           username: 'darttrust', useSSL: true);


### PR DESCRIPTION
Fixes #65

`_authenticator.onMessage(message);` was throwing `Null check operator used on a null value` exception but it was not propagated properly to the completer in the `open()` method. 