### PR TITLE
Add queryDirect API

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -3,6 +3,7 @@ library postgres;
 export 'src/connection.dart';
 export 'src/execution_context.dart';
 export 'src/models.dart';
+export 'src/query.dart' show ParameterValue;
 export 'src/replication.dart' show ReplicationMode;
 export 'src/substituter.dart';
 export 'src/types.dart';

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -427,7 +427,7 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
       return null;
     }
 
-    final dataType = typeMap[typeCode];
+    final dataType = PostgreSQLDataType.byTypeOid[typeCode];
 
     final buffer =
         ByteData.view(input.buffer, input.offsetInBytes, input.lengthInBytes);
@@ -565,35 +565,6 @@ class PostgresBinaryDecoder extends Converter<Uint8List, dynamic> {
 
     return decoded;
   }
-
-  /// See: https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat
-  static final Map<int, PostgreSQLDataType> typeMap = {
-    16: PostgreSQLDataType.boolean,
-    17: PostgreSQLDataType.byteArray,
-    19: PostgreSQLDataType.name,
-    20: PostgreSQLDataType.bigInteger,
-    21: PostgreSQLDataType.smallInteger,
-    23: PostgreSQLDataType.integer,
-    25: PostgreSQLDataType.text,
-    114: PostgreSQLDataType.json,
-    600: PostgreSQLDataType.point,
-    700: PostgreSQLDataType.real,
-    701: PostgreSQLDataType.double,
-    1000: PostgreSQLDataType.booleanArray,
-    1007: PostgreSQLDataType.integerArray,
-    1009: PostgreSQLDataType.textArray,
-    1015: PostgreSQLDataType.varCharArray,
-    1043: PostgreSQLDataType.varChar,
-    1022: PostgreSQLDataType.doubleArray,
-    1082: PostgreSQLDataType.date,
-    1114: PostgreSQLDataType.timestampWithoutTimezone,
-    1184: PostgreSQLDataType.timestampWithTimezone,
-    1186: PostgreSQLDataType.interval,
-    1700: PostgreSQLDataType.numeric,
-    2950: PostgreSQLDataType.uuid,
-    3802: PostgreSQLDataType.jsonb,
-    3807: PostgreSQLDataType.jsonbArray,
-  };
 
   /// Decode numeric / decimal to String without loosing precision.
   /// See encoding: https://github.com/postgres/postgres/blob/0e39a608ed5545cc6b9d538ac937c3c1ee8cdc36/src/backend/utils/adt/numeric.c#L305

--- a/lib/src/connection_fsm.dart
+++ b/lib/src/connection_fsm.dart
@@ -229,7 +229,7 @@ class _PostgreSQLConnectionStateIdle extends _PostgreSQLConnectionState {
 
   _PostgreSQLConnectionState processQuery(Query<dynamic> q) {
     try {
-      if (q.onlyReturnAffectedRowCount || q.useSendSimple) {
+      if (q.shouldUseSimpleProtocol) {
         q.sendSimple(connection!._socket!);
         return _PostgreSQLConnectionStateBusy(q);
       }
@@ -357,7 +357,7 @@ class _PostgreSQLConnectionStateReadyInTransaction
 
   _PostgreSQLConnectionState processQuery(Query<dynamic> q) {
     try {
-      if (q.onlyReturnAffectedRowCount || q.useSendSimple) {
+      if (q.shouldUseSimpleProtocol) {
         q.sendSimple(connection!._socket!);
         return _PostgreSQLConnectionStateBusy(q);
       }

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -55,6 +55,21 @@ abstract class PostgreSQLExecutionContext {
       int? timeoutInSeconds,
       bool? useSimpleQueryProtocol});
 
+  /// Runs a query with direct parameters.
+  ///
+  /// This method will send [sql] to the database without any modifications and
+  /// run it with the given [parameters].
+  ///
+  /// Unlike [query], this library will not attempt to inline any parameters
+  /// into the SQL string.
+  Future<PostgreSQLResult> queryDirect({
+    required String sql,
+    required List<ParameterValue> parameters,
+    bool? allowReuse,
+    bool? affectedRowsOnly,
+    int? timeoutInSeconds,
+  });
+
   /// Executes a query on this context.
   ///
   /// This method sends a SQL string to the database this instance is connected to. Parameters can be provided in [fmtString], see [query] for more details.

--- a/lib/src/logical_replication_messages.dart
+++ b/lib/src/logical_replication_messages.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:buffer/buffer.dart';
 
-import 'binary_codec.dart';
 import 'server_messages.dart';
 import 'shared_messages.dart';
 import 'time_converters.dart';
@@ -354,7 +353,7 @@ class TupleDataColumn {
   final int length;
 
   String get dataTypeName =>
-      PostgresBinaryDecoder.typeMap[dataType]?.name ?? dataType.toString();
+      PostgreSQLDataType.byTypeOid[dataType]?.name ?? dataType.toString();
 
   /// Data is the value of the column, in text format.
   /// n is the above length.

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -273,6 +273,11 @@ class ParameterValue {
     return ParameterValue._(true, bytes, length, postgresType);
   }
 
+  static ParameterValue typed<T extends Object>(
+      T? value, PostgreSQLDataType<T> type) {
+    return ParameterValue.binary(value, type);
+  }
+
   factory ParameterValue.text(dynamic value) {
     Uint8List? bytes;
     if (value != null) {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,3 +1,8 @@
+import 'dart:core';
+import 'dart:core' as core;
+
+import 'models.dart';
+
 /*
   Adding a new type:
 
@@ -10,98 +15,108 @@
  */
 
 /// Supported data types.
-enum PostgreSQLDataType {
+enum PostgreSQLDataType<Dart extends Object> {
   /// Must be a [String].
-  text,
+  text<String>(25),
 
   /// Must be an [int] (4-byte integer)
-  integer,
+  integer<int>(23),
 
   /// Must be an [int] (2-byte integer)
-  smallInteger,
+  smallInteger<int>(21),
 
   /// Must be an [int] (8-byte integer)
-  bigInteger,
+  bigInteger<int>(20),
 
   /// Must be an [int] (autoincrementing 4-byte integer)
-  serial,
+  serial(null),
 
   /// Must be an [int] (autoincrementing 8-byte integer)
-  bigSerial,
+  bigSerial(null),
 
   /// Must be a [double] (32-bit floating point value)
-  real,
+  real<core.double>(700),
 
   /// Must be a [double] (64-bit floating point value)
-  double,
+  double<core.double>(701),
 
   /// Must be a [bool]
-  boolean,
+  boolean<bool>(16),
 
   /// Must be a [DateTime] (microsecond date and time precision)
-  timestampWithoutTimezone,
+  timestampWithoutTimezone<DateTime>(1114),
 
   /// Must be a [DateTime] (microsecond date and time precision)
-  timestampWithTimezone,
+  timestampWithTimezone<DateTime>(1184),
 
   /// Must be a [Duration]
-  interval,
+  interval<Duration>(1186),
 
   /// Must be a [List<int>]
-  numeric,
+  numeric<List<int>>(1700),
 
   /// Must be a [DateTime] (contains year, month and day only)
-  date,
+  date<DateTime>(1082),
 
   /// Must be encodable via [json.encode].
   ///
   /// Values will be encoded via [json.encode] before being sent to the database.
-  jsonb,
+  jsonb(3802),
 
-  /// Must be encodable via [json.encode].
+  /// Must be encodable via [core.json.encode].
   ///
-  /// Values will be encoded via [json.encode] before being sent to the database.
-  json,
+  /// Values will be encoded via [core.json.encode] before being sent to the database.
+  json(114),
 
   /// Must be a [List] of [int].
   ///
   /// Each element of the list must fit into a byte (0-255).
-  byteArray,
+  byteArray<List<int>>(17),
 
   /// Must be a [String]
   ///
   /// Used for internal pg structure names
-  name,
+  name<String>(19),
 
   /// Must be a [String].
   ///
   /// Must contain 32 hexadecimal characters. May contain any number of '-' characters.
   /// When returned from database, format will be xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
-  uuid,
+  uuid<String>(2950),
 
   /// Must be a [PgPoint]
-  point,
+  point<PgPoint>(600),
 
   /// Must be a [List<bool>]
-  booleanArray,
+  booleanArray<List<bool>>(1000),
 
   /// Must be a [List<int>]
-  integerArray,
+  integerArray<List<int>>(1007),
 
   /// Must be a [List<String>]
-  textArray,
+  textArray<List<String>>(1009),
 
   /// Must be a [List<double>]
-  doubleArray,
+  doubleArray<List<core.double>>(1022),
 
   /// Must be a [String]
-  varChar,
+  varChar<String>(1043),
 
   /// Must be a [List<String>]
-  varCharArray,
+  varCharArray<List<String>>(1015),
 
   /// Must be a [List] of encodable objects
-  jsonbArray,
+  jsonbArray<List>(3807);
+
+  /// The object ID of this data type.
+  final int? oid;
+
+  const PostgreSQLDataType(this.oid);
+
+  static final Map<int, PostgreSQLDataType> byTypeOid = Map.unmodifiable({
+    for (final type in values)
+      if (type.oid != null) type.oid!: type,
+  });
 }
 
 /// LSN is a PostgreSQL Log Sequence Number.

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -656,7 +656,7 @@ Future expectInverse(dynamic value, PostgreSQLDataType dataType) async {
     dataType = PostgreSQLDataType.bigInteger;
   }
   late int code;
-  PostgresBinaryDecoder.typeMap.forEach((key, type) {
+  PostgreSQLDataType.byTypeOid.forEach((key, type) {
     if (type == dataType) {
       code = key;
     }

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -112,6 +112,29 @@ void main() {
       expect(result, 1);
     });
 
+    test('queryDirect', () async {
+      var result = await connection.queryDirect(
+        sql: r'SELECT $1, $2, $3, $4, $5;',
+        parameters: [
+          ParameterValue.typed<int>(null, PostgreSQLDataType.integer),
+          ParameterValue.typed(1, PostgreSQLDataType.integer),
+          ParameterValue.typed('hello', PostgreSQLDataType.text),
+          ParameterValue.typed([1, 2, 3, 4], PostgreSQLDataType.byteArray),
+          ParameterValue.typed(true, PostgreSQLDataType.boolean),
+        ],
+      );
+
+      expect(result, [
+        [
+          null,
+          1,
+          'hello',
+          [1, 2, 3, 4],
+          true
+        ]
+      ]);
+    });
+
     test('Query without specifying types', () async {
       var result = await connection.query(
           'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz, j, u, v, p, jj, ia, ta, da, ja, va, ba) values '


### PR DESCRIPTION
This adds a `queryDirect` API directly taking the parameters to bind a query to.

It also modifies the `Parse` request to include parameter types and refactors the `PostgreSQLDataType` enum to directly include its OID.