### PR TITLE
Improved exception message for column/data type missmatches

### DIFF
--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -246,59 +246,87 @@ class PostgresBinaryEncoder extends Converter<dynamic, Uint8List?> {
 
       case PostgreSQLDataType.booleanArray:
         {
-          if (input is List<bool>) {
-            return writeListBytes<bool>(input, 16, (_) => 1,
-                (writer, item) => writer.writeUint8(item ? 1 : 0));
+          if (input is List) {
+            return writeListBytes<dynamic>(input, 16, (_) => 1, (writer, item) {
+              if (item is! bool) {
+                throw FormatException(
+                    'Invalid type for parameter value. Expected: bool inside List but got ${input.runtimeType}');
+              }
+              writer.writeUint8(item ? 1 : 0);
+            });
           }
           throw FormatException(
-              'Invalid type for parameter value. Expected: List<bool> Got: ${input.runtimeType}');
+              'Invalid type for parameter value. Expected: List Got: ${input.runtimeType}');
         }
 
       case PostgreSQLDataType.integerArray:
         {
-          if (input is List<int>) {
-            return writeListBytes<int>(
-                input, 23, (_) => 4, (writer, item) => writer.writeInt32(item));
+          if (input is List) {
+            return writeListBytes<dynamic>(input, 23, (_) => 4, (writer, item) {
+              if (item is! int) {
+                throw FormatException(
+                    'Invalid type for parameter value. Expected: int inside List but got ${input.runtimeType}');
+              }
+              writer.writeInt32(item);
+            });
           }
           throw FormatException(
-              'Invalid type for parameter value. Expected: List<int> Got: ${input.runtimeType}');
+              'Invalid type for parameter value. Expected: List Got: ${input.runtimeType}');
         }
 
       case PostgreSQLDataType.varCharArray:
         {
-          if (input is List<String>) {
-            final bytesArray = input.map((v) => utf8.encode(v));
+          if (input is List) {
+            final bytesArray = input.map((v) {
+              if (v is! String) {
+                throw FormatException(
+                    'Invalid type for parameter value. Expected: String inside List but got ${input.runtimeType}');
+              }
+              return utf8.encode(v);
+            });
             return writeListBytes<List<int>>(bytesArray, 1043,
                 (item) => item.length, (writer, item) => writer.write(item));
           }
           throw FormatException(
-              'Invalid type for parameter value. Expected: List<String> Got: ${input.runtimeType}');
+              'Invalid type for parameter value. Expected: List Got: ${input.runtimeType}');
         }
 
       case PostgreSQLDataType.textArray:
         {
-          if (input is List<String>) {
-            final bytesArray = input.map((v) => utf8.encode(v));
+          if (input is List) {
+            final bytesArray = input.map((v) {
+              if (v is! String) {
+                throw FormatException(
+                    'Invalid type for parameter value. Expected: String inside List but got ${input.runtimeType}');
+              }
+              return utf8.encode(v);
+            });
             return writeListBytes<List<int>>(bytesArray, 25,
                 (item) => item.length, (writer, item) => writer.write(item));
           }
           throw FormatException(
-              'Invalid type for parameter value. Expected: List<String> Got: ${input.runtimeType}');
+              'Invalid type for parameter value. Expected: List Got: ${input.runtimeType}');
         }
 
       case PostgreSQLDataType.doubleArray:
         {
-          if (input is List<double>) {
-            return writeListBytes<double>(input, 701, (_) => 8,
-                (writer, item) => writer.writeFloat64(item));
+          if (input is List) {
+            return writeListBytes<dynamic>(input, 701, (_) => 8,
+                (writer, item) {
+              if (item is! double) {
+                throw FormatException(
+                    'Invalid type for parameter value. Expected: double inside List but got ${input.runtimeType}');
+              }
+              writer.writeFloat64(item);
+            });
           }
           throw FormatException(
-              'Invalid type for parameter value. Expected: List<double> Got: ${input.runtimeType}');
+              'Invalid type for parameter value. Expected: List Got: ${input.runtimeType}');
         }
 
       case PostgreSQLDataType.jsonbArray:
         {
-          if (input is List<Object>) {
+          if (input is List) {
             final objectsArray = input.map((v) => utf8.encode(json.encode(v)));
             return writeListBytes<List<int>>(
                 objectsArray, 3802, (item) => item.length + 1, (writer, item) {
@@ -307,7 +335,7 @@ class PostgresBinaryEncoder extends Converter<dynamic, Uint8List?> {
             });
           }
           throw FormatException(
-              'Invalid type for parameter value. Expected: List<Object> Got: ${input.runtimeType}');
+              'Invalid type for parameter value. Expected: List Got: ${input.runtimeType}');
         }
 
       default:


### PR DESCRIPTION
Hey,

debugging column type and data type mismatches took me forever, as the current code is really hard to debug in this case. I kept your code style (iterators etc.) but restructured the validation and added some basic information to the exception. The did already dump the whole query, but no hint of the issue. It now shows the specified type, the actual type of the column, as well as the name of the substitution placeholder.

It does not add a lot of overhead and is easier to debug if somebody ever puts a breakpoint inside. I previously had to use conditional breakpoints (actualType != specifiedType) which slows things down quite a bit. Hope you approve my pull request so I don't have to keep my fork :)

Cheers
quaaantumdev