### PR TITLE
V3: Fix deadlock for statements without a schema

### DIFF
--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -467,6 +467,16 @@ class _PgResultStreamSubscription
       _affectedRows.complete(message.rowsAffected);
     } else if (message is ReadyForQueryMessage) {
       _done.complete();
+
+      // Make sure the affectedRows and schema futures complete with something
+      // after the query is done, even if we didn't get a row description
+      // message.
+      if (!_affectedRows.isCompleted) {
+        _affectedRows.complete(0);
+      }
+      if (!_schema.isCompleted) {
+        _schema.complete(PgResultSchema(const []));
+      }
       await _controller.close();
     }
   }

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -39,6 +39,13 @@ void main() {
       ]);
     });
 
+    test('queries without a schema message', () async {
+      final response =
+          await connection.execute('CREATE TEMPORARY TABLE foo (bar INTEGER);');
+      expect(response.affectedRows, isZero);
+      expect(response.schema.columns, isEmpty);
+    });
+
     group('binary encoding and decoding', () {
       Future<void> shouldPassthrough<T extends Object>(
           PgDataType<T> type, T? value) async {


### PR DESCRIPTION
For DDL statements, postgres will not respond with a `RowDescriptionMessage`, which means that the completer for the `PgSchema` in a v3 query stream is never completed.

This is kind of counter-intuitive, and it breaks `PgSession.execute` which awaits the schema. To solve this problem, I've made the completers complete with default values if we didn't get anything back from postgres.