### PR TITLE
Query exceptions inside transactions will not propage out when caught with try-catch block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.7.0
+
+**Breaking behaviour**
+
+- Query exceptions inside transactions will not propage out when caught with try-catch block.
+
 ## 2.6.1
 
 - Added support for bigInt (int8) arrays. [#41](https://github.com/isoos/postgresql-dart/pull/88) by [schultek](https://github.com/schultek).

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -623,12 +623,9 @@ abstract class _PostgreSQLExecutionContextMixin
         final result =
             await query.future.timeout(Duration(seconds: timeoutInSeconds));
         _connection._cache.add(query);
-        _queue.remove(query);
         return result!;
-      } catch (e, st) {
+      } finally {
         _queue.remove(query);
-        await _onQueryError(query, e, st);
-        rethrow;
       }
     } else {
       // wrap the synchronous future in an async future to ensure that
@@ -638,8 +635,6 @@ abstract class _PostgreSQLExecutionContextMixin
       return Future(() async => (await query.future)!);
     }
   }
-
-  Future _onQueryError(Query query, dynamic error, [StackTrace? trace]) async {}
 }
 
 class _PostgreSQLResultMetaData {

--- a/lib/src/transaction_proxy.dart
+++ b/lib/src/transaction_proxy.dart
@@ -120,11 +120,6 @@ class _TransactionProxy extends Object
 
     await _cancelAndRollback(error, trace);
   }
-
-  @override
-  Future _onQueryError(Query query, dynamic error, [StackTrace? trace]) {
-    return _transactionFailed(error, trace);
-  }
 }
 
 /// Represents a rollback from a transaction.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol.
-version: 2.6.1
+version: 2.7.0
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:


### PR DESCRIPTION
Fixes #95.