### PR TITLE
Query substitution in V3 API

### DIFF
--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -128,11 +128,26 @@ abstract class PgStatement {
   Future<void> dispose();
 }
 
-class PgTypedParameter {
+/*final*/ class PgTypedParameter {
   final PgDataType type;
   final Object? value;
 
   PgTypedParameter(this.type, this.value);
+
+  @override
+  String toString() {
+    return 'PgTypedParameter($type, $value)';
+  }
+
+  @override
+  int get hashCode => Object.hash(type, value);
+
+  @override
+  bool operator ==(Object other) {
+    return other is PgTypedParameter &&
+        other.type == type &&
+        other.value == value;
+  }
 }
 
 abstract class PgResult implements List<PgResultRow> {

--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -128,7 +128,7 @@ abstract class PgStatement {
   Future<void> dispose();
 }
 
-/*final*/ class PgTypedParameter {
+final class PgTypedParameter {
   final PgDataType type;
   final Object? value;
 
@@ -180,7 +180,7 @@ abstract class PgResultRow implements List<Object?> {
   PgResultSchema get schema;
 }
 
-class PgResultSchema {
+final class PgResultSchema {
   final List<PgResultColumn> columns;
 
   PgResultSchema(this.columns);
@@ -191,7 +191,7 @@ class PgResultSchema {
   }
 }
 
-class PgResultColumn {
+final class PgResultColumn {
   final PgDataType type;
   final String? tableName;
   final int? tableOid;
@@ -237,9 +237,7 @@ abstract class PgChannels {
   Future<void> cancelAll();
 }
 
-abstract class PgNotification {}
-
-class PgEndpoint {
+final class PgEndpoint {
   final String host;
   final int port;
   final String database;
@@ -266,7 +264,7 @@ class PgEndpoint {
   });
 }
 
-class PgSessionSettings {
+final class PgSessionSettings {
   // Duration(seconds: 15)
   final Duration? connectTimeout;
   // Duration(minutes: 5)
@@ -297,7 +295,7 @@ class PgSessionSettings {
   });
 }
 
-class PgPoolSettings {
+final class PgPoolSettings {
   final int? maxConnectionCount;
   final Duration? idleTestThreshold;
   final Duration? maxConnectionAge;

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -453,7 +453,7 @@ class _OidCache {
   }
 }
 
-abstract class _PostgreSQLExecutionContextMixin
+abstract mixin class _PostgreSQLExecutionContextMixin
     implements PostgreSQLExecutionContext {
   final _queue = QueryQueue();
 

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -330,35 +330,8 @@ class PostgreSQLFormatToken {
 }
 
 class PostgreSQLFormatIdentifier {
-  static Map<String, PostgreSQLDataType> typeStringToCodeMap = {
-    'text': PostgreSQLDataType.text,
-    'int2': PostgreSQLDataType.smallInteger,
-    'int4': PostgreSQLDataType.integer,
-    'int8': PostgreSQLDataType.bigInteger,
-    'float4': PostgreSQLDataType.real,
-    'float8': PostgreSQLDataType.double,
-    'boolean': PostgreSQLDataType.boolean,
-    'date': PostgreSQLDataType.date,
-    'timestamp': PostgreSQLDataType.timestampWithoutTimezone,
-    'timestamptz': PostgreSQLDataType.timestampWithTimezone,
-    'interval': PostgreSQLDataType.interval,
-    'numeric': PostgreSQLDataType.numeric,
-    'jsonb': PostgreSQLDataType.jsonb,
-    'bytea': PostgreSQLDataType.byteArray,
-    'name': PostgreSQLDataType.name,
-    'uuid': PostgreSQLDataType.uuid,
-    'json': PostgreSQLDataType.json,
-    'point': PostgreSQLDataType.point,
-    '_bool': PostgreSQLDataType.booleanArray,
-    '_int4': PostgreSQLDataType.integerArray,
-    '_int8': PostgreSQLDataType.bigIntegerArray,
-    '_text': PostgreSQLDataType.textArray,
-    '_float8': PostgreSQLDataType.doubleArray,
-    'varchar': PostgreSQLDataType.varChar,
-    'regtype': PostgreSQLDataType.regtype,
-    '_varchar': PostgreSQLDataType.varCharArray,
-    '_jsonb': PostgreSQLDataType.jsonbArray,
-  };
+  static Map<String, PostgreSQLDataType> typeStringToCodeMap =
+      PostgreSQLDataType.bySubstitutionName;
 
   factory PostgreSQLFormatIdentifier(String t) {
     String name;

--- a/lib/src/substituter.dart
+++ b/lib/src/substituter.dart
@@ -27,52 +27,7 @@ class PostgreSQLFormat {
         return 'int4';
       case PostgreSQLDataType.bigSerial:
         return 'int8';
-      case PostgreSQLDataType.real:
-        return 'float4';
-      case PostgreSQLDataType.double:
-        return 'float8';
-      case PostgreSQLDataType.boolean:
-        return 'boolean';
-      case PostgreSQLDataType.timestampWithoutTimezone:
-        return 'timestamp';
-      case PostgreSQLDataType.timestampWithTimezone:
-        return 'timestamptz';
-      case PostgreSQLDataType.interval:
-        return 'interval';
-      case PostgreSQLDataType.numeric:
-        return 'numeric';
-      case PostgreSQLDataType.date:
-        return 'date';
-      case PostgreSQLDataType.jsonb:
-        return 'jsonb';
-      case PostgreSQLDataType.byteArray:
-        return 'bytea';
-      case PostgreSQLDataType.name:
-        return 'name';
-      case PostgreSQLDataType.uuid:
-        return 'uuid';
-      case PostgreSQLDataType.point:
-        return 'point';
-      case PostgreSQLDataType.json:
-        return 'json';
-      case PostgreSQLDataType.booleanArray:
-        return '_bool';
-      case PostgreSQLDataType.integerArray:
-        return '_int4';
-      case PostgreSQLDataType.bigIntegerArray:
-        return '_int8';
-      case PostgreSQLDataType.textArray:
-        return '_text';
-      case PostgreSQLDataType.doubleArray:
-        return '_float8';
-      case PostgreSQLDataType.varChar:
-        return 'varchar';
-      case PostgreSQLDataType.varCharArray:
-        return '_varchar';
-      case PostgreSQLDataType.jsonbArray:
-        return '_jsonb';
-      case PostgreSQLDataType.regtype:
-        return 'regtype';
+
       default:
         return null;
     }

--- a/lib/src/substituter.dart
+++ b/lib/src/substituter.dart
@@ -14,23 +14,7 @@ class PostgreSQLFormat {
   }
 
   static String? dataTypeStringForDataType(PostgreSQLDataType? dt) {
-    switch (dt) {
-      case PostgreSQLDataType.text:
-        return 'text';
-      case PostgreSQLDataType.integer:
-        return 'int4';
-      case PostgreSQLDataType.smallInteger:
-        return 'int2';
-      case PostgreSQLDataType.bigInteger:
-        return 'int8';
-      case PostgreSQLDataType.serial:
-        return 'int4';
-      case PostgreSQLDataType.bigSerial:
-        return 'int8';
-
-      default:
-        return null;
-    }
+    return dt?.nameForSubstitution;
   }
 
   static String substitute(String fmtString, Map<String, dynamic>? values,

--- a/lib/src/v3/query_description.dart
+++ b/lib/src/v3/query_description.dart
@@ -10,13 +10,30 @@ class InternalQueryDescription implements PgSql {
   /// The SQL query as supplied by the user.
   final String originalSql;
 
-  final List<PgDataType>? parameterTypes;
+  final List<PgDataType?>? parameterTypes;
+  final Map<String, int>? namedVariables;
 
   InternalQueryDescription._(
-      this.transformedSql, this.originalSql, this.parameterTypes);
+    this.transformedSql,
+    this.originalSql,
+    this.parameterTypes,
+    this.namedVariables,
+  );
 
   InternalQueryDescription.direct(String sql, {List<PgDataType>? types})
-      : this._(sql, sql, types);
+      : this._(sql, sql, types, null);
+
+  InternalQueryDescription.transformed(
+    String original,
+    String transformed,
+    List<PgDataType?> parameterTypes,
+    Map<String, int> namedVariables,
+  ) : this._(
+          transformed,
+          original,
+          parameterTypes,
+          namedVariables,
+        );
 
   factory InternalQueryDescription.map(String sql,
       {String substitution = '@'}) {

--- a/lib/src/v3/query_description.dart
+++ b/lib/src/v3/query_description.dart
@@ -117,11 +117,21 @@ class InternalQueryDescription implements PgSql {
             knownTypes![variableIndex - 1]; // Known types are 0-indexed
 
         final name = entry.key;
+        if (!params.containsKey(name)) {
+          throw ArgumentError.value(
+              params, 'parameters', 'Missing variable for `$name`');
+        }
+
         final value = params[name];
         unmatchedVariables.remove(name);
         parameters.add(_toParameter(value, type));
 
         variableIndex++;
+      }
+
+      if (unmatchedVariables.isNotEmpty) {
+        throw ArgumentError.value(params, 'parameters',
+            'Contains superfluous variables: ${unmatchedVariables.join(', ')}');
       }
     } else {
       throw ArgumentError.value(

--- a/lib/src/v3/query_description.dart
+++ b/lib/src/v3/query_description.dart
@@ -1,5 +1,7 @@
 import 'package:postgres/postgres_v3_experimental.dart';
 
+import 'variable_tokenizer.dart';
+
 class InternalQueryDescription implements PgSql {
   /// The SQL to send to postgres.
   ///
@@ -37,8 +39,16 @@ class InternalQueryDescription implements PgSql {
 
   factory InternalQueryDescription.map(String sql,
       {String substitution = '@'}) {
-    // todo: Scan sql query, apply transformation
-    throw UnimplementedError();
+    final charCodes = substitution.codeUnits;
+    if (charCodes.length != 1) {
+      throw ArgumentError.value(substitution, 'substitution',
+          'Must be a string with a single code unit');
+    }
+
+    final tokenizer =
+        VariableTokenizer(variableCodeUnit: charCodes[0], sql: sql)..tokenize();
+
+    return tokenizer.result;
   }
 
   factory InternalQueryDescription.wrap(Object query) {
@@ -54,8 +64,24 @@ class InternalQueryDescription implements PgSql {
     }
   }
 
+  PgTypedParameter _toParameter(Object? value, PgDataType? knownType) {
+    if (value is PgTypedParameter) {
+      return value;
+    } else if (knownType != null) {
+      return PgTypedParameter(knownType, value);
+    } else {
+      throw ArgumentError.value(
+        value,
+        'parameter',
+        'Is not a `PgTypedParameter` and appears in a location for which no '
+            'type could be inferred.',
+      );
+    }
+  }
+
   List<PgTypedParameter> bindParameters(Object? params) {
     final knownTypes = parameterTypes;
+    final parameters = <PgTypedParameter>[];
 
     if (params == null) {
       if (knownTypes != null && knownTypes.isNotEmpty) {
@@ -70,29 +96,38 @@ class InternalQueryDescription implements PgSql {
             'Expected ${knownTypes.length} parameters, got ${params.length}');
       }
 
-      final parameters = <PgTypedParameter>[];
       for (var i = 0; i < params.length; i++) {
         final param = params[i];
-        if (param is PgTypedParameter) {
-          parameters.add(param);
-        } else if (knownTypes != null) {
-          parameters.add(PgTypedParameter(knownTypes[i], param));
-        } else {
-          throw ArgumentError.value(
-            params,
-            'parameters',
-            'As no types have been set on this prepared statement, all '
-                'parameters must be a `PgTypedParameter`.',
-          );
-        }
+        final knownType = knownTypes != null ? knownTypes[i] : null;
+
+        parameters.add(_toParameter(param, knownType));
+      }
+    } else if (params is Map) {
+      final byName = namedVariables;
+      final unmatchedVariables = params.keys.toSet();
+      if (byName == null) {
+        throw ArgumentError.value(
+            params, 'parameters', 'Maps are only supported by `PgSql.map`');
       }
 
-      return parameters;
-    } else if (params is Map) {
-      throw UnimplementedError('todo: Support binding maps');
+      var variableIndex = 1;
+      for (final entry in byName.entries) {
+        assert(entry.value == variableIndex);
+        final type =
+            knownTypes![variableIndex - 1]; // Known types are 0-indexed
+
+        final name = entry.key;
+        final value = params[name];
+        unmatchedVariables.remove(name);
+        parameters.add(_toParameter(value, type));
+
+        variableIndex++;
+      }
     } else {
       throw ArgumentError.value(
           params, 'parameters', 'Must either be a list or a map');
     }
+
+    return parameters;
   }
 }

--- a/lib/src/v3/types.dart
+++ b/lib/src/v3/types.dart
@@ -44,10 +44,10 @@ enum PgDataType<Dart extends Object> {
   bigInteger<int>(20, nameForSubstitution: 'int8'),
 
   /// Must be an [int] (autoincrementing 4-byte integer)
-  serial(null),
+  serial(null, nameForSubstitution: 'int4'),
 
   /// Must be an [int] (autoincrementing 8-byte integer)
-  bigSerial(null),
+  bigSerial(null, nameForSubstitution: 'int8'),
 
   /// Must be a [double] (32-bit floating point value)
   real<core.double>(700, nameForSubstitution: 'float4'),
@@ -62,7 +62,7 @@ enum PgDataType<Dart extends Object> {
   timestampWithoutTimezone<DateTime>(1114, nameForSubstitution: 'timestamp'),
 
   /// Must be a [DateTime] (microsecond date and time precision)
-  timestampWithTimezone<DateTime>(1184, nameForSubstitution: 'timestampz'),
+  timestampWithTimezone<DateTime>(1184, nameForSubstitution: 'timestamptz'),
 
   /// Must be a [Duration]
   interval<Duration>(1186, nameForSubstitution: 'interval'),
@@ -161,7 +161,14 @@ enum PgDataType<Dart extends Object> {
 
   static final Map<String, PgDataType> bySubstitutionName = Map.unmodifiable({
     for (final type in values)
-      if (type.nameForSubstitution != null) type.nameForSubstitution!: type,
+      // We don't index serial and bigSerial types here because they're using
+      // the same names as int4 and int8, respectively.
+      // However, when a user is referring to these types in a query, they
+      // should always resolve to integer and bigInteger.
+      if (type != serial &&
+          type != bigSerial &&
+          type.nameForSubstitution != null)
+        type.nameForSubstitution!: type,
   });
 
   static final Map<PgDataType, _BinaryTypeCodec> _binaryCodecs = {};

--- a/lib/src/v3/types.dart
+++ b/lib/src/v3/types.dart
@@ -32,16 +32,16 @@ enum PgDataType<Dart extends Object> {
   unknownType<Object>(null),
 
   /// Must be a [String].
-  text<String>(25),
+  text<String>(25, nameForSubstitution: 'text'),
 
   /// Must be an [int] (4-byte integer)
-  integer<int>(23),
+  integer<int>(23, nameForSubstitution: 'int4'),
 
   /// Must be an [int] (2-byte integer)
-  smallInteger<int>(21),
+  smallInteger<int>(21, nameForSubstitution: 'int2'),
 
   /// Must be an [int] (8-byte integer)
-  bigInteger<int>(20),
+  bigInteger<int>(20, nameForSubstitution: 'int8'),
 
   /// Must be an [int] (autoincrementing 4-byte integer)
   serial(null),
@@ -50,84 +50,84 @@ enum PgDataType<Dart extends Object> {
   bigSerial(null),
 
   /// Must be a [double] (32-bit floating point value)
-  real<core.double>(700),
+  real<core.double>(700, nameForSubstitution: 'float4'),
 
   /// Must be a [double] (64-bit floating point value)
-  double<core.double>(701),
+  double<core.double>(701, nameForSubstitution: 'float8'),
 
   /// Must be a [bool]
-  boolean<bool>(16),
+  boolean<bool>(16, nameForSubstitution: 'boolean'),
 
   /// Must be a [DateTime] (microsecond date and time precision)
-  timestampWithoutTimezone<DateTime>(1114),
+  timestampWithoutTimezone<DateTime>(1114, nameForSubstitution: 'timestamp'),
 
   /// Must be a [DateTime] (microsecond date and time precision)
-  timestampWithTimezone<DateTime>(1184),
+  timestampWithTimezone<DateTime>(1184, nameForSubstitution: 'timestampz'),
 
   /// Must be a [Duration]
-  interval<Duration>(1186),
+  interval<Duration>(1186, nameForSubstitution: 'interval'),
 
   /// Must be a [List<int>]
-  numeric<List<int>>(1700),
+  numeric<List<int>>(1700, nameForSubstitution: 'numeric'),
 
   /// Must be a [DateTime] (contains year, month and day only)
-  date<DateTime>(1082),
+  date<DateTime>(1082, nameForSubstitution: 'date'),
 
   /// Must be encodable via [json.encode].
   ///
   /// Values will be encoded via [json.encode] before being sent to the database.
-  jsonb(3802),
+  jsonb(3802, nameForSubstitution: 'jsonb'),
 
   /// Must be encodable via [core.json.encode].
   ///
   /// Values will be encoded via [core.json.encode] before being sent to the database.
-  json(114),
+  json(114, nameForSubstitution: 'json'),
 
   /// Must be a [List] of [int].
   ///
   /// Each element of the list must fit into a byte (0-255).
-  byteArray<List<int>>(17),
+  byteArray<List<int>>(17, nameForSubstitution: 'bytea'),
 
   /// Must be a [String]
   ///
   /// Used for internal pg structure names
-  name<String>(19),
+  name<String>(19, nameForSubstitution: 'name'),
 
   /// Must be a [String].
   ///
   /// Must contain 32 hexadecimal characters. May contain any number of '-' characters.
   /// When returned from database, format will be xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
-  uuid<String>(2950),
+  uuid<String>(2950, nameForSubstitution: 'uuid'),
 
   /// Must be a [PgPoint]
-  point<PgPoint>(600),
+  point<PgPoint>(600, nameForSubstitution: 'point'),
 
   /// Must be a [List<bool>]
-  booleanArray<List<bool>>(1000),
+  booleanArray<List<bool>>(1000, nameForSubstitution: '_bool'),
 
   /// Must be a [List<int>]
-  integerArray<List<int>>(1007),
+  integerArray<List<int>>(1007, nameForSubstitution: '_int4'),
 
   /// Must be a [List<int>]
-  bigIntegerArray<List<int>>(1016),
+  bigIntegerArray<List<int>>(1016, nameForSubstitution: '_int8'),
 
   /// Must be a [List<String>]
-  textArray<List<String>>(1009),
+  textArray<List<String>>(1009, nameForSubstitution: '_text'),
 
   /// Must be a [List<double>]
-  doubleArray<List<core.double>>(1022),
+  doubleArray<List<core.double>>(1022, nameForSubstitution: '_float8'),
 
   /// Must be a [String]
-  varChar<String>(1043),
+  varChar<String>(1043, nameForSubstitution: 'varchar'),
 
   /// Must be a [List<String>]
-  varCharArray<List<String>>(1015),
+  varCharArray<List<String>>(1015, nameForSubstitution: '_varchar'),
 
   /// Must be a [List] of encodable objects
-  jsonbArray<List>(3807),
+  jsonbArray<List>(3807, nameForSubstitution: '_jsonb'),
 
   /// Must be a [PgDataType].
-  regtype<PgDataType>(2206),
+  regtype<PgDataType>(2206, nameForSubstitution: 'regtype'),
 
   /// Impossible to bind to, always null when read.
   voidType<Object>(2278),
@@ -135,6 +135,12 @@ enum PgDataType<Dart extends Object> {
 
   /// The object ID of this data type.
   final int? oid;
+
+  /// The name of this type as considered by [PgSql.map].
+  ///
+  /// To declare an explicit type for a substituted parameter in a query, this
+  /// name can be used.
+  final String? nameForSubstitution;
 
   Codec<Dart?, Uint8List?> get binaryCodec {
     return _binaryCodecs.putIfAbsent(this, () => _BinaryTypeCodec<Dart>(this))
@@ -146,11 +152,16 @@ enum PgDataType<Dart extends Object> {
         as Codec<Dart?, Uint8List?>;
   }
 
-  const PgDataType(this.oid);
+  const PgDataType(this.oid, {this.nameForSubstitution});
 
   static final Map<int, PgDataType> byTypeOid = Map.unmodifiable({
     for (final type in values)
       if (type.oid != null) type.oid!: type,
+  });
+
+  static final Map<String, PgDataType> bySubstitutionName = Map.unmodifiable({
+    for (final type in values)
+      if (type.nameForSubstitution != null) type.nameForSubstitution!: type,
   });
 
   static final Map<PgDataType, _BinaryTypeCodec> _binaryCodecs = {};

--- a/lib/src/v3/variable_tokenizer.dart
+++ b/lib/src/v3/variable_tokenizer.dart
@@ -1,0 +1,228 @@
+import 'package:charcode/charcode.dart';
+
+import 'query_description.dart';
+import 'types.dart';
+
+/// In addition to indexed variables supported by the postgres protocol, most
+/// postgres clients (including this package) support a variable mode in which
+/// variables are identified by `@` followed by a name and an optional type.a
+class VariableTokenizer {
+  final Map<String, int> _namedVariables = {};
+  final Map<int, PgDataType> _variableTypes = {};
+  final StringBuffer _rewrittenSql = StringBuffer();
+
+  final int _variableCodeUnit;
+  final String _source;
+  final List<int> _codeUnits;
+
+  int _index = 0;
+
+  bool get _isAtEnd => _index == _codeUnits.length;
+
+  VariableTokenizer({
+    int variableCodeUnit = 64, // @
+    required String sql,
+  })  : _variableCodeUnit = variableCodeUnit,
+        _source = sql,
+        _codeUnits = sql.codeUnits;
+
+  InternalQueryDescription get result {
+    return InternalQueryDescription.transformed(
+      _source,
+      _rewrittenSql.toString(),
+      [
+        for (final entry in _namedVariables.entries)
+          _variableTypes[entry.value],
+      ],
+      _namedVariables,
+    );
+  }
+
+  int _consume() => _codeUnits[_index++];
+
+  bool _consumeIfMatches(int charCode) {
+    if (_isAtEnd) return false;
+
+    final next = _codeUnits[_index];
+    if (next == charCode) {
+      _index++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  void tokenize() {
+    nextToken:
+    while (!_isAtEnd) {
+      final startIndex = _index;
+      final charCode = _consume();
+
+      if (charCode == _variableCodeUnit) {
+        _startVariable(startIndex);
+        break nextToken;
+      } else {
+        switch (charCode) {
+          case $slash:
+            // `/*`, block comment
+            if (_consumeIfMatches($asterisk)) {
+              _blockComment();
+              break nextToken;
+            }
+            break;
+          case $minus:
+            // `--`, line comment
+            if (_consumeIfMatches($minus)) {
+              _lineComment();
+              break nextToken;
+            }
+            break;
+          case $doubleQuote:
+            // Double quote has already been consumed, but is part of the identifier
+            _rewrittenSql.writeCharCode($doubleQuote);
+            _continueEscapedIdentifier();
+            break nextToken;
+          case $singleQuote:
+            // Write start of string that has already been consumed
+            _rewrittenSql.writeCharCode($singleQuote);
+            _continueStringLiteral(enableEscapes: false);
+            break nextToken;
+          case $e:
+          case $E:
+            if (_consumeIfMatches($singleQuote)) {
+              // https://cloud.google.com/spanner/docs/reference/postgresql/lexical#string_constants_with_c-style_escapes
+              _rewrittenSql
+                ..writeCharCode(charCode) // e or E
+                ..writeCharCode($singleQuote);
+
+              _continueStringLiteral(enableEscapes: true);
+              break nextToken;
+            }
+        }
+      }
+
+      // This char has no special meaning, add it to the SQL string.
+      _rewrittenSql.writeCharCode(charCode);
+    }
+  }
+
+  void _blockComment() {
+    // Look for `*/` sequence to end the comment
+    while (!_isAtEnd) {
+      final char = _consume();
+      if (char == $asterisk) {
+        if (_consumeIfMatches($slash)) return;
+      }
+    }
+  }
+
+  void _lineComment() {
+    // Consume the rest of the line without adding it.
+    while (!_isAtEnd) {
+      final char = _consume();
+      if (char == $cr || char == $lf) return;
+    }
+  }
+
+  void _continueStringLiteral({required bool enableEscapes}) {
+    while (!_isAtEnd) {
+      final char = _consume();
+
+      if (char == $singleQuote) {
+        // Two adjacent single quotes are a escape sequence and don't end the
+        // string
+        if (_consumeIfMatches($singleQuote)) {
+          _rewrittenSql
+            ..writeCharCode($singleQuote)
+            ..writeCharCode($singleQuote);
+        } else {
+          // End of string
+          _rewrittenSql.writeCharCode(char);
+          return;
+        }
+      }
+
+      _rewrittenSql.writeCharCode(char);
+
+      if (enableEscapes && char == $backslash) {
+        // If this is followed by a single quote, it is escaped and doesn't end
+        // the string.
+        if (_consumeIfMatches($singleQuote)) {
+          _rewrittenSql.writeCharCode($singleQuote);
+        }
+      }
+    }
+  }
+
+  void _continueEscapedIdentifier() {
+    while (!_isAtEnd) {
+      final char = _consume();
+      _rewrittenSql.writeCharCode(char);
+
+      if (char == $doubleQuote) return;
+    }
+  }
+
+  void _startVariable(int startPosition) {
+    // The syntax for a variable is `@<variableName>(:<typeName>)?`. When this
+    // method gets called, the at character has already been consumed.
+    final nameBuffer = StringBuffer();
+    final typeBuffer = StringBuffer();
+
+    Never error(String message) {
+      final lexeme = _source.substring(startPosition, _index);
+
+      throw FormatException(
+          'Error at offset $startPosition ($lexeme): $message');
+    }
+
+    var isReadingName = true;
+    var consumedColonForType = false;
+    int? charAfterVariable;
+
+    while (_isAtEnd) {
+      final nextChar = _consume();
+      if (_isAlphanumeric(nextChar)) {
+        if (isReadingName) {
+          nameBuffer.writeCharCode(nextChar);
+        } else {
+          typeBuffer.writeCharCode(nextChar);
+        }
+      } else if (!consumedColonForType && nextChar == $colon) {
+        consumedColonForType = true;
+        isReadingName = false;
+      } else {
+        charAfterVariable = nextChar;
+        break;
+      }
+    }
+
+    if (nameBuffer.isEmpty) {
+      error('Empty variable name');
+    }
+    if (consumedColonForType && typeBuffer.isEmpty) {
+      error('Expected type name after colon');
+    }
+
+    final actualVariableIndex = _namedVariables.putIfAbsent(
+        nameBuffer.toString(), () => _namedVariables.length);
+
+    if (consumedColonForType) {
+      final typeName = typeBuffer.toString();
+      final type = PgDataType.date; // todo: Construct type based on name or err
+
+      _variableTypes[actualVariableIndex] = type;
+    }
+
+    _rewrittenSql.write('\$$actualVariableIndex');
+    if (charAfterVariable != null) {
+      _rewrittenSql.writeCharCode(charAfterVariable);
+    }
+  }
+
+  static bool _isAlphanumeric(int charcode) {
+    return (charcode >= $0 && charcode <= $9) ||
+        (charcode >= $a && charcode <= $z) ||
+        (charcode >= $A && charcode <= $Z);
+  }
+}

--- a/lib/src/v3/variable_tokenizer.dart
+++ b/lib/src/v3/variable_tokenizer.dart
@@ -250,8 +250,16 @@ class VariableTokenizer {
     }
 
     if (nameBuffer.isEmpty) {
-      error('Empty variable name');
+      // No variable then. The variable declaration syntax conflicts with some
+      // postgres operators (e.g `@>`). So in that case, we just write the
+      // original syntax.
+      _rewrittenSql.writeCharCode(_variableCodeUnit);
+      if (charAfterVariable != null) {
+        _rewrittenSql.writeCharCode(charAfterVariable);
+      }
+      return;
     }
+
     if (consumedColonForType && typeBuffer.isEmpty) {
       error('Expected type name after colon');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.6.2
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   buffer: ^1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.6.2
 homepage: https://github.com/isoos/postgresql-dart
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   buffer: ^1.1.0

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -152,6 +152,34 @@ void main() {
       ]);
     });
 
+    test('can use mapped queries with json-contains operator', () async {
+      final rows = await connection.execute(
+        PgSql.map('SELECT @a:jsonb @> @b:jsonb'),
+        parameters: {
+          'a': {'foo': 'bar', 'another': 'as well'},
+          'b': {'foo': 'bar'},
+        },
+      );
+
+      expect(rows, [
+        [true]
+      ]);
+    });
+
+    test('can use json path predicate check operator', () async {
+      final rows = await connection.execute(
+        PgSql.map('SELECT @a:jsonb @@ @b:text::jsonpath'),
+        parameters: {
+          'a': [1, 2, 3, 4, 5],
+          'b': r'$.a[*] > 2',
+        },
+      );
+
+      expect(rows, [
+        [false]
+      ]);
+    });
+
     group('throws error', () {
       setUp(() async {
         await connection

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -133,6 +133,16 @@ void main() {
       await connection.channels.notify(channel);
     });
 
+    test('can use same variable multiple times', () async {
+      final stmt = await connection.prepare(
+          PgSql(r'SELECT $1 AS a, $1 + 2 AS b', types: [PgDataType.integer]));
+      final rows = await stmt.run([10]);
+
+      expect(rows, [
+        [10, 12]
+      ]);
+    });
+
     group('throws error', () {
       setUp(() async {
         await connection

--- a/test/variable_tokenizer_test.dart
+++ b/test/variable_tokenizer_test.dart
@@ -56,6 +56,15 @@ void main() {
     expect(desc.namedVariables?.keys, ['x', 'y']);
   });
 
+  test('can use custom variable symbol', () {
+    final desc = InternalQueryDescription.map(
+        'SELECT * FROM foo WHERE a = :x:int8',
+        substitution: ':');
+    expect(desc.transformedSql, r'SELECT * FROM foo WHERE a = $1');
+    expect(desc.namedVariables?.keys, ['x']);
+    expect(desc.parameterTypes, [PgDataType.bigInteger]);
+  });
+
   group('ignores', () {
     test('line comments', () {
       final desc = InternalQueryDescription.map('SELECT @1, -- @2 \n @3');
@@ -99,6 +108,12 @@ void main() {
 
     test('for variable with empty type name', () {
       expect(() => InternalQueryDescription.map('SELECT @var: FROM foo'),
+          throwsFormatException);
+    });
+
+    test('for invalid type name', () {
+      expect(
+          () => InternalQueryDescription.map('SELECT @var:nosuchtype FROM foo'),
           throwsFormatException);
     });
   });

--- a/test/variable_tokenizer_test.dart
+++ b/test/variable_tokenizer_test.dart
@@ -1,0 +1,105 @@
+import 'package:postgres/postgres_v3_experimental.dart';
+import 'package:postgres/src/v3/query_description.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('can declare variables', () {
+    final desc = InternalQueryDescription.map('SELECT @x:int8, @y:boolean, @z');
+
+    expect(desc.transformedSql, r'SELECT $1, $2, $3');
+    expect(
+      desc.namedVariables,
+      {'x': 1, 'y': 2, 'z': 3},
+    );
+    expect(desc.parameterTypes, [
+      PgDataType.bigInteger, // x
+      PgDataType.boolean, // y
+      null, // z, didn't have a specified type
+    ]);
+
+    expect(() => desc.bindParameters(null), throwsArgumentError);
+
+    expect(
+      desc.bindParameters(
+          {'x': 4, 'y': true, 'z': PgTypedParameter(PgDataType.text, 'z')}),
+      [
+        PgTypedParameter(PgDataType.bigInteger, 4),
+        PgTypedParameter(PgDataType.boolean, true),
+        PgTypedParameter(PgDataType.text, 'z'),
+      ],
+    );
+    expect(() => desc.bindParameters({'x': 4, 'y': true, 'z': 'z'}),
+        throwsArgumentError,
+        reason: 'No data type given for z');
+
+    // Make sure we can still bind by index
+    expect(
+      desc.bindParameters([1, true, PgTypedParameter(PgDataType.text, 'z')]),
+      [
+        PgTypedParameter(PgDataType.bigInteger, 1),
+        PgTypedParameter(PgDataType.boolean, true),
+        PgTypedParameter(PgDataType.text, 'z'),
+      ],
+    );
+    expect(
+      () => desc.bindParameters([1, true, 3]),
+      throwsArgumentError,
+      reason: 'No data type given for third parameter',
+    );
+  });
+
+  test('can use the same variable more than once', () {
+    final desc = InternalQueryDescription.map(
+        'SELECT * FROM foo WHERE a = @x OR bar = @y OR b = @x');
+    expect(desc.transformedSql,
+        r'SELECT * FROM foo WHERE a = $1 OR bar = $2 OR b = $1');
+    expect(desc.namedVariables?.keys, ['x', 'y']);
+  });
+
+  group('ignores', () {
+    test('line comments', () {
+      final desc = InternalQueryDescription.map('SELECT @1, -- @2 \n @3');
+      expect(desc.transformedSql, r'SELECT $1,  $2');
+      expect(desc.namedVariables?.keys, ['1', '3']);
+    });
+
+    test('block comments', () {
+      final desc = InternalQueryDescription.map(
+          'SELECT @1 /* this is ignored: @2 */, @3');
+      expect(desc.transformedSql, r'SELECT $1 , $2');
+      expect(desc.namedVariables?.keys, ['1', '3']);
+    });
+
+    test('string literals', () {
+      final desc = InternalQueryDescription.map(
+          "SELECT @1, 'isn''t a variable: @2', @3");
+      expect(desc.transformedSql, r"SELECT $1, 'isn''t a variable: @2', $2");
+      expect(desc.namedVariables?.keys, ['1', '3']);
+    });
+
+    test('string literals with C-style escapes', () {
+      final desc = InternalQueryDescription.map(
+          r"SELECT @1, E'isn\'t a variable: @2', @3");
+      expect(desc.transformedSql, r"SELECT $1, E'isn\'t a variable: @2', $2");
+      expect(desc.namedVariables?.keys, ['1', '3']);
+    });
+
+    test('identifiers', () {
+      final desc = InternalQueryDescription.map('SELECT @1 AS "@2", @3');
+      expect(desc.transformedSql, r'SELECT $1 AS "@2", $2');
+      expect(desc.namedVariables?.keys, ['1', '3']);
+    });
+  });
+
+  group('throws', () {
+    test('for variable with empty name', () {
+      expect(() => InternalQueryDescription.map('SELECT @ FROM foo'),
+          throwsFormatException);
+    });
+
+    test('for variable with empty type name', () {
+      expect(() => InternalQueryDescription.map('SELECT @var: FROM foo'),
+          throwsFormatException);
+    });
+  });
+}

--- a/test/variable_tokenizer_test.dart
+++ b/test/variable_tokenizer_test.dart
@@ -98,14 +98,19 @@ void main() {
       expect(desc.transformedSql, r'SELECT $1 AS "@2", $2');
       expect(desc.namedVariables?.keys, ['1', '3']);
     });
+
+    // https://www.postgresql.org/docs/current/functions-json.html
+    final operators = ['@>', '<@', '@?', '@@'];
+    for (final operator in operators) {
+      test('can use $operator', () {
+        final desc = InternalQueryDescription.map('SELECT @foo $operator @bar');
+        expect(desc.transformedSql, 'SELECT \$1 $operator \$2');
+        expect(desc.namedVariables?.keys, ['foo', 'bar']);
+      });
+    }
   });
 
   group('throws', () {
-    test('for variable with empty name', () {
-      expect(() => InternalQueryDescription.map('SELECT @ FROM foo'),
-          throwsFormatException);
-    });
-
     test('for variable with empty type name', () {
       expect(() => InternalQueryDescription.map('SELECT @var: FROM foo'),
           throwsFormatException);

--- a/test/variable_tokenizer_test.dart
+++ b/test/variable_tokenizer_test.dart
@@ -116,5 +116,31 @@ void main() {
           () => InternalQueryDescription.map('SELECT @var:nosuchtype FROM foo'),
           throwsFormatException);
     });
+
+    test('for missing variable', () {
+      expect(
+        () => InternalQueryDescription.map('SELECT @foo').bindParameters({}),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          'Missing variable for `foo`',
+        )),
+      );
+    });
+
+    test('for superfluous variables', () {
+      expect(
+        () => InternalQueryDescription.map('SELECT @foo:int4').bindParameters({
+          'foo': 3,
+          'X': 'Y',
+          'Y': 'Z',
+        }),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          'Contains superfluous variables: X, Y',
+        )),
+      );
+    });
   });
 }


### PR DESCRIPTION
This:

- Adds the type name used for the old substitution logic into the `PgDataType` definition, avoiding that being duplicated.
- Implements `PgSql.map` by lexing the postgres statement.

I've tried to keep the new interface close to the old one, but I think there are some opportunities to improve it that are breaking:

- When a variable is declared with `SELECT @foo`, the name in the map is just `foo` instead of `@foo`. I think this might make variables easier to bind when using custom substitution chars and generally makes the map more pleasant to look at.
- Only variables that are actual variables are considered. When a substitution character appears in a string literal, an identifier or a comment, it is ignored.