### PR TITLE
Pool implementation for the v3 API

### DIFF
--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -13,7 +13,7 @@ import 'src/v3/types.dart';
 export 'src/v3/types.dart';
 
 abstract class PgPool implements PgSession, PgSessionExecutor {
-  static PgPool open(
+  factory PgPool(
     List<PgEndpoint> endpoints, {
     PgSessionSettings? sessionSettings,
     PgPoolSettings? poolSettings,

--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'src/v3/connection.dart';
+import 'src/v3/pool.dart';
 import 'src/v3/protocol.dart';
 import 'src/v3/query_description.dart';
 import 'src/v3/types.dart';
@@ -13,13 +13,18 @@ import 'src/v3/types.dart';
 export 'src/v3/types.dart';
 
 abstract class PgPool implements PgSession, PgSessionExecutor {
-  static Future<PgPool> open(
+  static PgPool open(
     List<PgEndpoint> endpoints, {
     PgSessionSettings? sessionSettings,
     PgPoolSettings? poolSettings,
   }) =>
-      throw UnimplementedError();
+      PoolImplementation(endpoints, sessionSettings, poolSettings);
 
+  /// Acquires a connection from this pool, opening a new one if necessary, and
+  /// calls [fn] with it.
+  ///
+  /// The connection must not be used after [fn] returns as it could be used by
+  /// another [withConnection] call later.
   Future<R> withConnection<R>(
     Future<R> Function(PgConnection connection) fn, {
     PgSessionSettings? sessionSettings,
@@ -107,10 +112,7 @@ abstract class PgSession {
   ///
   /// When the returned future completes, the statement must eventually be freed
   /// using [PgStatement.close] to avoid resource leaks.
-  Future<PgStatement> prepare(
-    Object /* String | PgSql */ query, {
-    Duration? timeout,
-  });
+  Future<PgStatement> prepare(Object /* String | PgSql */ query);
 
   /// Executes the [query] with the given [parameters].
   ///
@@ -129,7 +131,6 @@ abstract class PgSession {
     Object /* String | PgSql */ query, {
     Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */
         parameters,
-    Duration? timeout,
     bool ignoreRows = false,
   });
 
@@ -187,9 +188,8 @@ abstract class PgStatement {
 
   Future<PgResult> run(
     Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */
-        parameters, {
-    Duration? timeout,
-  }) async {
+        parameters,
+  ) async {
     final items = <PgResultRow>[];
     final subscription = bind(parameters).listen(items.add);
     await subscription.asFuture();
@@ -342,9 +342,8 @@ final class PgSessionSettings {
   // Duration(seconds: 15)
   final Duration? connectTimeout;
   // Duration(minutes: 5)
-  final Duration? queryTimeout;
   final String? timeZone;
-  final Encoding? encoding;
+
   final bool Function(X509Certificate)? onBadSslCertificate;
 
   /// An optional [StreamChannelTransformer] sitting behind the postgres client
@@ -361,9 +360,7 @@ final class PgSessionSettings {
 
   PgSessionSettings({
     this.connectTimeout,
-    this.queryTimeout,
     this.timeZone,
-    this.encoding,
     this.onBadSslCertificate,
     this.transformer,
   });
@@ -371,18 +368,8 @@ final class PgSessionSettings {
 
 final class PgPoolSettings {
   final int? maxConnectionCount;
-  final Duration? idleTestThreshold;
-  final Duration? maxConnectionAge;
-  final Duration? maxSessionUse;
-  final int? maxErrorCount;
-  final int? maxQueryCount;
 
-  PgPoolSettings({
+  const PgPoolSettings({
     this.maxConnectionCount,
-    this.idleTestThreshold,
-    this.maxConnectionAge,
-    this.maxSessionUse,
-    this.maxErrorCount,
-    this.maxQueryCount,
   });
 }

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -34,9 +33,9 @@ class _ResolvedSettings {
   final String password;
 
   final Duration connectTimeout;
-  final Duration queryTimeout;
+  //final Duration queryTimeout;
   final String timeZone;
-  final Encoding encoding;
+  //final Encoding encoding;
 
   final StreamChannelTransformer<BaseMessage, BaseMessage>? transformer;
 
@@ -47,9 +46,9 @@ class _ResolvedSettings {
         password = endpoint.password ?? 'postgres',
         connectTimeout =
             settings?.connectTimeout ?? const Duration(seconds: 15),
-        queryTimeout = settings?.connectTimeout ?? const Duration(minutes: 5),
+        //queryTimeout = settings?.connectTimeout ?? const Duration(minutes: 5),
         timeZone = settings?.timeZone ?? 'UTC',
-        encoding = settings?.encoding ?? utf8,
+        // encoding = settings?.encoding ?? utf8,
         transformer = settings?.transformer;
 
   bool onBadSslCertificate(X509Certificate certificate) {
@@ -111,7 +110,6 @@ abstract class _PgSessionBase implements PgSession {
   Future<PgResult> execute(
     Object query, {
     Object? parameters,
-    Duration? timeout,
     bool ignoreRows = false,
   }) async {
     final description = InternalQueryDescription.wrap(query);
@@ -120,9 +118,9 @@ abstract class _PgSessionBase implements PgSession {
     if (!ignoreRows || variables.isNotEmpty) {
       // The simple query protocol does not support variables and returns rows
       // as text. So when we need rows or parameters, we need an explicit prepare.
-      final prepared = await prepare(description, timeout: timeout);
+      final prepared = await prepare(description);
       try {
-        return await prepared.run(variables, timeout: timeout);
+        return await prepared.run(variables);
       } finally {
         await prepared.dispose();
       }
@@ -147,7 +145,7 @@ abstract class _PgSessionBase implements PgSession {
   }
 
   @override
-  Future<PgStatement> prepare(Object query, {Duration? timeout}) async {
+  Future<PgStatement> prepare(Object query) async {
     final conn = _connection;
     final name = 's/${conn._statementCounter++}';
     final description = InternalQueryDescription.wrap(query);

--- a/lib/src/v3/pool.dart
+++ b/lib/src/v3/pool.dart
@@ -43,7 +43,7 @@ class PoolImplementation implements PgPool {
 
   @override
   Future<PgResult> execute(Object query,
-      {Object? parameters, Duration? timeout, bool ignoreRows = false}) {
+      {Object? parameters, bool ignoreRows = false}) {
     return withConnection((connection) => connection.execute(
           query,
           parameters: parameters,
@@ -52,7 +52,7 @@ class PoolImplementation implements PgPool {
   }
 
   @override
-  Future<PgStatement> prepare(Object query, {Duration? timeout}) async {
+  Future<PgStatement> prepare(Object query) async {
     final statementCompleter = Completer<PgStatement>.sync();
 
     unawaited(withConnection((connection) async {
@@ -108,10 +108,11 @@ class PoolImplementation implements PgPool {
       if (connection == null) {
         connection ??= _OpenedConnection(
           await PgConnectionImplementation.connect(_nextEndpoint),
-        )..isInUse = true;
+        );
         _openConnections.add(connection);
       }
 
+      connection.isInUse = true;
       final poolConnection = _PoolConnection(connection.connection);
       return await fn(poolConnection);
     } finally {
@@ -156,7 +157,7 @@ class _PoolConnection implements PgConnection {
 
   @override
   Future<PgResult> execute(Object query,
-      {Object? parameters, Duration? timeout, bool ignoreRows = false}) {
+      {Object? parameters, bool ignoreRows = false}) {
     return _connection.execute(
       query,
       parameters: parameters,
@@ -165,7 +166,7 @@ class _PoolConnection implements PgConnection {
   }
 
   @override
-  Future<PgStatement> prepare(Object query, {Duration? timeout}) {
+  Future<PgStatement> prepare(Object query) {
     return _connection.prepare(query);
   }
 
@@ -196,7 +197,7 @@ class _PoolStatement implements PgStatement {
   }
 
   @override
-  Future<PgResult> run(Object? parameters, {Duration? timeout}) {
+  Future<PgResult> run(Object? parameters) {
     return _underlying.run(parameters);
   }
 }

--- a/lib/src/v3/pool.dart
+++ b/lib/src/v3/pool.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+
+import 'package:pool/pool.dart';
+import 'package:postgres/postgres_v3_experimental.dart';
+
+import 'connection.dart';
+
+class PoolImplementation implements PgPool {
+  final List<PgEndpoint> endpoints;
+  final PgSessionSettings? sessionSettings;
+  final PgPoolSettings? poolSettings;
+
+  final Pool _pool;
+  final List<_OpenedConnection> _openConnections = [];
+
+  int _nextEndpointIndex = 0;
+
+  PoolImplementation(this.endpoints, this.sessionSettings, this.poolSettings)
+      : _pool = Pool(
+          poolSettings?.maxConnectionCount ?? 1000,
+        );
+
+  /// Returns the next endpoint from [endpoints], cycling through them.
+  PgEndpoint get _nextEndpoint {
+    final endpoint = endpoints[_nextEndpointIndex];
+    _nextEndpointIndex = (_nextEndpointIndex + 1) % endpoints.length;
+
+    return endpoint;
+  }
+
+  @override
+  Future<void> close() async {
+    await _pool.close();
+
+    // Connections are closed when they are returned to the pool if it's closed.
+    // We still need to close statements that are currently unused.
+    for (final connection in _openConnections) {
+      if (!connection.isInUse) {
+        await connection.connection.close();
+      }
+    }
+  }
+
+  @override
+  Future<PgResult> execute(Object query,
+      {Object? parameters, Duration? timeout, bool ignoreRows = false}) {
+    return withConnection((connection) => connection.execute(
+          query,
+          parameters: parameters,
+          ignoreRows: ignoreRows,
+        ));
+  }
+
+  @override
+  Future<PgStatement> prepare(Object query, {Duration? timeout}) async {
+    final statementCompleter = Completer<PgStatement>.sync();
+
+    unawaited(withConnection((connection) async {
+      _PoolStatement? poolStatement;
+
+      try {
+        final statement = await connection.prepare(query);
+        poolStatement = _PoolStatement(statement);
+      } on Object catch (e, s) {
+        // Could not prepare the statement, inform the caller and stop occupying
+        // the connection.
+        statementCompleter.completeError(e, s);
+        return;
+      }
+
+      // Otherwise, make the future returned by prepare complete with the
+      // statement.
+      statementCompleter.complete(poolStatement);
+
+      // And keep this connection reserved until the statement has been disposed.
+      return poolStatement._disposed.future;
+    }));
+
+    return statementCompleter.future;
+  }
+
+  @override
+  Future<R> run<R>(Future<R> Function(PgSession session) fn) {
+    return withConnection((connection) => connection.run(fn));
+  }
+
+  @override
+  Future<R> runTx<R>(Future<R> Function(PgSession session) fn) {
+    return withConnection((connection) => connection.runTx(fn));
+  }
+
+  @override
+  Future<R> withConnection<R>(Future<R> Function(PgConnection connection) fn,
+      {PgSessionSettings? sessionSettings}) async {
+    final resource = await _pool.request();
+
+    // Find an existing connection that is currently unused, or open another
+    // one.
+    _OpenedConnection? connection;
+    for (final opened in _openConnections) {
+      if (!opened.isInUse) {
+        connection = opened;
+        break;
+      }
+    }
+
+    try {
+      if (connection == null) {
+        connection ??= _OpenedConnection(
+          await PgConnectionImplementation.connect(_nextEndpoint),
+        )..isInUse = true;
+        _openConnections.add(connection);
+      }
+
+      final poolConnection = _PoolConnection(connection.connection);
+      return await fn(poolConnection);
+    } finally {
+      connection?.isInUse = false;
+      resource.release();
+
+      // If the pool has been closed, this connection needs to be closed as
+      // well.
+      if (_pool.isClosed) {
+        await connection?.connection.close();
+      }
+    }
+  }
+}
+
+/// An opened [PgConnection] we're able to use in [PgPool.withConnection].
+class _OpenedConnection {
+  bool isInUse = false;
+  final PgConnectionImplementation connection;
+
+  _OpenedConnection(this.connection);
+}
+
+class _PoolConnection implements PgConnection {
+  final PgConnectionImplementation _connection;
+
+  _PoolConnection(this._connection);
+
+  @override
+  PgChannels get channels {
+    throw UnsupportedError(
+      'Channels are not supported in pools because they would require keeping '
+      'the connection open even after `withConnection` has returned.',
+    );
+  }
+
+  @override
+  Future<void> close() async {
+    // Don't forward the close call, the underlying connection should be re-used
+    // when another pool connection is requested.
+  }
+
+  @override
+  Future<PgResult> execute(Object query,
+      {Object? parameters, Duration? timeout, bool ignoreRows = false}) {
+    return _connection.execute(
+      query,
+      parameters: parameters,
+      ignoreRows: ignoreRows,
+    );
+  }
+
+  @override
+  Future<PgStatement> prepare(Object query, {Duration? timeout}) {
+    return _connection.prepare(query);
+  }
+
+  @override
+  Future<R> run<R>(Future<R> Function(PgSession session) fn) {
+    return _connection.run(fn);
+  }
+
+  @override
+  Future<R> runTx<R>(Future<R> Function(PgSession session) fn) {
+    return _connection.runTx(fn);
+  }
+}
+
+class _PoolStatement implements PgStatement {
+  final Completer<void> _disposed = Completer();
+  final PgStatement _underlying;
+
+  _PoolStatement(this._underlying);
+
+  @override
+  PgResultStream bind(Object? parameters) => _underlying.bind(parameters);
+
+  @override
+  Future<void> dispose() async {
+    _disposed.complete();
+    await _underlying.dispose();
+  }
+
+  @override
+  Future<PgResult> run(Object? parameters, {Duration? timeout}) {
+    return _underlying.run(parameters);
+  }
+}

--- a/lib/src/v3/pool.dart
+++ b/lib/src/v3/pool.dart
@@ -119,13 +119,15 @@ class PoolImplementation implements PgPool {
       final poolConnection = _PoolConnection(connection.connection);
       return await fn(poolConnection);
     } finally {
-      connection?.isInUse = false;
       resource.release();
 
       // If the pool has been closed, this connection needs to be closed as
       // well.
       if (_pool.isClosed) {
         await connection?.connection.close();
+      } else {
+        // Allow the connection to be re-used later.
+        connection?.isInUse = false;
       }
     }
   }

--- a/lib/src/v3/pool.dart
+++ b/lib/src/v3/pool.dart
@@ -107,7 +107,10 @@ class PoolImplementation implements PgPool {
     try {
       if (connection == null) {
         connection ??= _OpenedConnection(
-          await PgConnectionImplementation.connect(_nextEndpoint),
+          await PgConnectionImplementation.connect(
+            _nextEndpoint,
+            sessionSettings: sessionSettings ?? this.sessionSettings,
+          ),
         );
         _openConnections.add(connection);
       }

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+
+import 'package:postgres/postgres_v3_experimental.dart';
+import 'package:test/test.dart';
+
+import 'docker.dart';
+
+final _endpoint = PgEndpoint(
+  host: 'localhost',
+  database: 'dart_test',
+  username: 'dart',
+  password: 'dart',
+);
+
+void main() {
+  usePostgresDocker();
+
+  group('generic', () {
+    late PgPool pool;
+
+    setUp(() => pool = PgPool.open([_endpoint]));
+    tearDown(() => pool.close());
+
+    test('does not support channels', () {
+      expect(pool.withConnection((c) async => c.channels.notify('foo')),
+          throwsUnsupportedError);
+    });
+
+    test('execute re-uses free connection', () async {
+      // The temporary table is only visible to the connection creating it, so
+      // this asserts that all statements are running on the same underlying
+      // connection.
+      await pool.execute('CREATE TEMPORARY TABLE foo (bar INTEGER);');
+
+      await pool.execute('INSERT INTO foo VALUES (1), (2), (3);');
+      final results = await pool.execute('SELECT * FROM foo');
+      expect(results, hasLength(3));
+    });
+
+    test('can use transactions', () async {
+      // The table can't be temporary because it needs to be visible across
+      // connections.
+      await pool.execute(
+          'CREATE TABLE IF NOT EXISTS transaction_test (bar INTEGER);');
+      addTearDown(() => pool.execute('DROP TABLE transaction_test;'));
+
+      final completeTransaction = Completer();
+      final transaction = pool.runTx((session) async {
+        await pool
+            .execute('INSERT INTO transaction_test VALUES (1), (2), (3);');
+        await completeTransaction.future;
+      });
+
+      var rows = await pool.execute('SELECT * FROM transaction_test');
+      expect(rows, isEmpty);
+
+      completeTransaction.complete();
+      await transaction;
+
+      rows = await pool.execute('SELECT * FROM transaction_test');
+      expect(rows, hasLength(3));
+    });
+
+    test('can use prepared statements', () async {
+      await pool
+          .execute('CREATE TABLE IF NOT EXISTS statements_test (bar INTEGER);');
+      addTearDown(() => pool.execute('DROP TABLE statements_test;'));
+
+      final stmt = await pool.prepare('SELECT * FROM statements_test');
+      expect(await stmt.run([]), isEmpty);
+
+      await pool.execute('INSERT INTO statements_test VALUES (1), (2), (3);');
+
+      expect(await stmt.run([]), hasLength(3));
+      await stmt.dispose();
+    });
+  });
+
+  test('can limit concurrent connections', () async {
+    final pool = PgPool.open(
+      [_endpoint],
+      poolSettings: const PgPoolSettings(maxConnectionCount: 2),
+    );
+    addTearDown(pool.close);
+
+    final wait = Completer();
+
+    // Take two connections
+    unawaited(pool.withConnection((connection) => wait.future));
+    unawaited(pool.withConnection((connection) => wait.future));
+
+    // Creating a third one should block.
+    var didInvokeCallback = false;
+    unawaited(pool.withConnection((connection) async {
+      didInvokeCallback = true;
+    }));
+
+    await pumpEventQueue();
+    expect(didInvokeCallback, isFalse);
+
+    wait.complete();
+    await pumpEventQueue();
+    expect(didInvokeCallback, isTrue);
+  });
+}


### PR DESCRIPTION
This PR removes some options and parameters that aren't implemented yet (like timeouts). Adding them back won't be breaking, so it's something we can implement later. It seems like none of these features (except timeouts) are supported by the v2 API either. And since timeouts can't be implemented in a clever way (there's no way in the protocol to cancel existing queries, for instance), users should probably just timeout the future themselves instead?

Removing these options made it somewhat easier to implement a simple pool that creates connections when they are first used and is able to re-use them.