### PR TITLE
chore: Remove deprecated lints.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,8 +25,7 @@ linter:
 #  - empty_catches
   - empty_statements
   - hash_and_equals
-  - iterable_contains_unrelated_type
-  - list_remove_unrelated_type
+  - collection_methods_unrelated_type
   - no_adjacent_strings_in_list
   - no_duplicate_case_values
   - non_constant_identifier_names


### PR DESCRIPTION
Both iterable_contains_unrelated_type and list_remove_unrelated_type were replaced by collection_methods_unrelated_type.