### PR TITLE
fix: PgPoint.hashCode is wrong.

### DIFF
--- a/lib/src/v3/types.dart
+++ b/lib/src/v3/types.dart
@@ -4,11 +4,13 @@ import 'dart:core' as core;
 import 'dart:typed_data';
 
 import 'package:buffer/buffer.dart';
+import 'package:meta/meta.dart';
 
 import '../binary_codec.dart';
 import '../text_codec.dart';
 
 /// Describes PostgreSQL's geometric type: `point`.
+@immutable
 class PgPoint {
   final double latitude;
   final double longitude;
@@ -23,7 +25,7 @@ class PgPoint {
           longitude == other.longitude;
 
   @override
-  int get hashCode => latitude.hashCode ^ longitude.hashCode;
+  int get hashCode => Object.hash(latitude, longitude);
 }
 
 /// Supported data types.

--- a/test/types_test.dart
+++ b/test/types_test.dart
@@ -16,4 +16,12 @@ void main() {
       expect(lsn.toString(), '16/B374D848');
     });
   });
+
+  group('PgPoint type', () {
+    test('- PgPoint hashcode', () {
+      final point = PgPoint(1.0, 2.0);
+      final point2 = PgPoint(2.0, 1.0);
+      expect(point.hashCode, isNot(point2.hashCode));
+    });
+  });
 }


### PR DESCRIPTION
Oring hashCode values is an old style which is wrong in the case of swapped values.  Fixed by using Object.hash.

Also marked PgPoint immutable, since that's the modern style.