### PR TITLE
fix: add no_default_cases lint and remove unnecessary defaults

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,6 +28,7 @@ linter:
   - iterable_contains_unrelated_type
   - list_remove_unrelated_type
   - no_adjacent_strings_in_list
+  - no_default_cases
   - no_duplicate_case_values
   - non_constant_identifier_names
   - only_throw_errors

--- a/lib/src/auth/auth.dart
+++ b/lib/src/auth/auth.dart
@@ -2,7 +2,6 @@ import 'package:crypto/crypto.dart';
 import 'package:sasl_scram/sasl_scram.dart';
 
 import '../../messages.dart';
-import '../../postgres.dart';
 import 'clear_text_authenticator.dart';
 import 'md5_authenticator.dart';
 import 'sasl_authenticator.dart';
@@ -50,7 +49,5 @@ PostgresAuthenticator createAuthenticator(PostgresAuthConnection connection,
           connection, ScramAuthenticator('SCRAM-SHA-256', sha256, credentials));
     case AuthenticationScheme.clear:
       return ClearAuthenticator(connection);
-    default:
-      throw PostgreSQLException("Authenticator wasn't specified");
   }
 }

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:buffer/buffer.dart';
 import 'package:postgres/src/v3/types.dart';
 
-import '../postgres.dart' show PostgreSQLException;
 import 'types.dart';
 
 final _bool0 = Uint8List(1)..[0] = 0;
@@ -335,9 +334,6 @@ class PostgresBinaryEncoder<T extends Object>
           throw FormatException(
               'Invalid type for parameter value. Expected: List<Object> Got: ${input.runtimeType}');
         }
-
-      default:
-        throw PostgreSQLException('Unsupported datatype');
     }
   }
 
@@ -565,7 +561,9 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
           return json.decode(utf8.decode(bytes));
         }) as T;
 
-      default:
+      case PostgreSQLDataType.unknownType:
+      // TODO(eseidel): This looks wrong for null?
+      case null:
         {
           // We'll try and decode this as a utf8 string and return that
           // for many internal types, this is valid. If it fails,

--- a/lib/src/logical_replication_messages.dart
+++ b/lib/src/logical_replication_messages.dart
@@ -83,7 +83,6 @@ LogicalReplicationMessage? tryParseLogicalReplicationMessage(
       return TruncateMessage(bytes);
 
     case LogicalReplicationMessageTypes.Unsupported:
-    default:
       // note this needs the full set of bytes unlike other cases
       return _tryParseJsonMessage(bytesList);
   }
@@ -567,7 +566,7 @@ class DeleteMessage implements LogicalReplicationMessage {
       case DeleteMessageTuple.oldType:
         oldTuple = TupleData(reader);
         break;
-      default:
+      case DeleteMessageTuple.unknown:
         throw Exception('Unknown tuple type for DeleteMessage');
     }
   }

--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -243,6 +243,9 @@ class PostgresTextDecoder<T extends Object> extends Converter<Uint8List?, T?> {
         return num.parse(asText) as T;
       case PgDataType.boolean:
         return (asText == 'true') as T;
+
+      // We could list out all cases, but it's about 20 lines of code.
+      // ignore: no_default_cases
       default:
         throw UnimplementedError('Text decoding for $_dataType');
     }


### PR DESCRIPTION
Modern dart (especially with sealed) makes it easy to avoid default in most cases, so adding the lint and removing all but one.

I think this may have unearthed a bug in binary_codec, but I wasn't sure of the fix so just left a TODO for now.