### PR TITLE
chore: Add unnecessary_breaks

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -50,6 +50,7 @@ linter:
   - type_init_formals
   - unawaited_futures
   - unnecessary_brace_in_string_interps
+  - unnecessary_breaks
   - unnecessary_getters_setters
   - unnecessary_lambdas
   - unnecessary_new

--- a/lib/src/auth/sasl_authenticator.dart
+++ b/lib/src/auth/sasl_authenticator.dart
@@ -28,7 +28,6 @@ class PostgresSaslAuthenticator extends PostgresAuthenticator {
           throw PostgreSQLException('KindSASL: No bytes to send');
         }
         msg = SaslClientFirstMessage(bytesToSend, authenticator.mechanism.name);
-        break;
       case AuthenticationMessage.KindSASLContinue:
         final bytesToSend = authenticator.handleMessage(
             SaslMessageType.AuthenticationSASLContinue, message.bytes);
@@ -36,7 +35,6 @@ class PostgresSaslAuthenticator extends PostgresAuthenticator {
           throw PostgreSQLException('KindSASLContinue: No bytes to send');
         }
         msg = SaslClientLastMessage(bytesToSend);
-        break;
       case AuthenticationMessage.KindSASLFinal:
         authenticator.handleMessage(
             SaslMessageType.AuthenticationSASLFinal, message.bytes);

--- a/lib/src/logical_replication_messages.dart
+++ b/lib/src/logical_replication_messages.dart
@@ -394,12 +394,10 @@ class TupleData {
         case TupleDataType.binaryType:
           length = reader.readUint32();
           data = reader.read(length);
-          break;
         case TupleDataType.nullType:
         case TupleDataType.toastType:
           length = 0;
           data = Uint8List(0);
-          break;
       }
       columns.add(
         TupleDataColumn(
@@ -566,7 +564,6 @@ class DeleteMessage implements LogicalReplicationMessage {
       case DeleteMessageTuple.keyType:
       case DeleteMessageTuple.oldType:
         oldTuple = TupleData(reader);
-        break;
       default:
         throw Exception('Unknown tuple type for DeleteMessage');
     }

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -725,7 +725,6 @@ class _AuthenticationProcedure extends _PendingOperation {
           break;
         case AuthenticationMessage.KindMD5Password:
           _initializeAuthenticate(message, AuthenticationScheme.md5);
-          break;
         case AuthenticationMessage.KindClearTextPassword:
           if (!connection._settings.endpoint.allowCleartextPassword) {
             _done.completeError(
@@ -738,14 +737,11 @@ class _AuthenticationProcedure extends _PendingOperation {
           }
 
           _initializeAuthenticate(message, AuthenticationScheme.clear);
-          break;
         case AuthenticationMessage.KindSASL:
           _initializeAuthenticate(message, AuthenticationScheme.scramSha256);
-          break;
         case AuthenticationMessage.KindSASLContinue:
         case AuthenticationMessage.KindSASLFinal:
           _authenticator.onMessage(message);
-          break;
         default:
           _done.completeError(PostgreSQLException('Unhandled auth mechanism'));
       }

--- a/lib/src/v3/variable_tokenizer.dart
+++ b/lib/src/v3/variable_tokenizer.dart
@@ -105,14 +105,12 @@ class VariableTokenizer {
               _blockComment();
               continue nextToken;
             }
-            break;
           case $minus:
             // `--`, line comment
             if (_consumeIfMatches($minus)) {
               _lineComment();
               continue nextToken;
             }
-            break;
           case $doubleQuote:
             // Double quote has already been consumed, but is part of the identifier
             // Note that this also handles identifiers with unicode escape


### PR DESCRIPTION
Dart case statements don't fall through like C++s do so breaks are unnecessary.

Please feel free to reject any of these changes if they don't match your desired style.