### PR TITLE
chore: add uneccessary_* lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -57,6 +57,9 @@ linter:
   - unnecessary_lambdas
   - unnecessary_new
   - unnecessary_null_aware_assignments
+  - unnecessary_null_checks
+  - unnecessary_parenthesis
+  - unnecessary_raw_strings
   - unnecessary_statements
   - unnecessary_this
   - unrelated_type_equality_checks

--- a/example/v3/example.dart
+++ b/example/v3/example.dart
@@ -5,7 +5,7 @@ void main() async {
   final connection = await PgConnection.open(database);
   print('has connection!');
 
-  final statement = await connection.prepare(PgSql(r"SELECT 'foo';"));
+  final statement = await connection.prepare(PgSql("SELECT 'foo';"));
   print('has statement');
   final result = await statement.run();
   print(result);

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -28,7 +28,7 @@ final _hex = <String>[
   'f',
 ];
 final _numericRegExp = RegExp(r'^(\d*)(\.\d*)?$');
-final _leadingZerosRegExp = RegExp(r'^0+');
+final _leadingZerosRegExp = RegExp('^0+');
 final _trailingZerosRegExp = RegExp(r'0+$');
 
 class PostgresBinaryEncoder<T extends Object>

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -45,9 +45,9 @@ class PostgreSQLException implements Exception {
   }
 
   PostgreSQLException._(List<ErrorField> errorFields) {
-    ErrorField finder(int identifer) => (errorFields.firstWhere(
-        (ErrorField e) => e.identificationToken == identifer,
-        orElse: () => ErrorField(null, null)));
+    ErrorField finder(int identifier) => errorFields.firstWhere(
+        (ErrorField e) => e.identificationToken == identifier,
+        orElse: () => ErrorField(null, null));
 
     severity = ErrorField.severityFromString(
         finder(ErrorField.SeverityIdentifier).text);

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -64,7 +64,7 @@ class Query<T> {
 
   void sendExtended(Socket socket, {CachedQuery? cacheQuery}) {
     if (cacheQuery != null) {
-      fieldDescriptions = cacheQuery.fieldDescriptions!;
+      fieldDescriptions = cacheQuery.fieldDescriptions;
       sendCachedQuery(socket, cacheQuery, substitutionValues);
 
       return;
@@ -95,7 +95,7 @@ class Query<T> {
     ];
 
     if (statementIdentifier != null) {
-      cache = CachedQuery(statementIdentifier!, formatIdentifiers);
+      cache = CachedQuery(statementIdentifier, formatIdentifiers);
     }
 
     socket.add(ClientMessage.aggregateBytes(messages));
@@ -351,7 +351,7 @@ class PostgreSQLFormatIdentifier {
 
       final dataTypeString = variableComponents.last;
       try {
-        type = typeStringToCodeMap[dataTypeString]!;
+        type = typeStringToCodeMap[dataTypeString];
       } catch (e) {
         throw FormatException(
             "Invalid type code in substitution variable '$t'");

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -352,6 +352,10 @@ class PostgreSQLFormatIdentifier {
       final dataTypeString = variableComponents.last;
       try {
         type = typeStringToCodeMap[dataTypeString];
+        if (type == null) {
+          throw FormatException(
+              "Invalid type code in substitution variable '$t'");
+        }
       } catch (e) {
         throw FormatException(
             "Invalid type code in substitution variable '$t'");

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -350,13 +350,8 @@ class PostgreSQLFormatIdentifier {
       name = variableComponents.first;
 
       final dataTypeString = variableComponents.last;
-      try {
-        type = typeStringToCodeMap[dataTypeString];
-        if (type == null) {
-          throw FormatException(
-              "Invalid type code in substitution variable '$t'");
-        }
-      } catch (e) {
+      type = typeStringToCodeMap[dataTypeString];
+      if (type == null) {
         throw FormatException(
             "Invalid type code in substitution variable '$t'");
       }

--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -57,7 +57,7 @@ class PostgresTextEncoder extends Converter<Object, String> {
     }
 
     final backslashCodeUnit = r'\'.codeUnitAt(0);
-    final quoteCodeUnit = r"'".codeUnitAt(0);
+    final quoteCodeUnit = "'".codeUnitAt(0);
 
     var quoteCount = 0;
     var backslashCount = 0;

--- a/lib/src/v3/types.dart
+++ b/lib/src/v3/types.dart
@@ -158,7 +158,7 @@ enum PgDataType<Dart extends Object> {
 
   static final Map<int, PgDataType> byTypeOid = Map.unmodifiable({
     for (final type in values)
-      if (type.oid != null) type.oid!: type,
+      if (type.oid != null) type.oid: type,
   });
 
   static final Map<String, PgDataType> bySubstitutionName = Map.unmodifiable({
@@ -170,7 +170,7 @@ enum PgDataType<Dart extends Object> {
       if (type != serial &&
           type != bigSerial &&
           type.nameForSubstitution != null)
-        type.nameForSubstitution!: type,
+        type.nameForSubstitution: type,
   });
 
   static final Map<PgDataType, _BinaryTypeCodec> _binaryCodecs = {};

--- a/test/map_return_test.dart
+++ b/test/map_return_test.dart
@@ -142,7 +142,7 @@ void clearOidQueryCount(PostgreSQLConnection connection) {
           dm.simpleName.toString().contains('_oidCache'));
   // TODO(eseidel): Fix this by using @visibleForTesting instead of mirrors?
   // ignore: avoid_dynamic_calls
-  (reflect(connection).getField(oidCacheMirror.simpleName).reflectee).clear();
+  reflect(connection).getField(oidCacheMirror.simpleName).reflectee.clear();
 }
 
 int getOidQueryCount(PostgreSQLConnection connection) {
@@ -154,6 +154,8 @@ int getOidQueryCount(PostgreSQLConnection connection) {
           dm.simpleName.toString().contains('_oidCache'));
   // TODO(eseidel): Fix this by using @visibleForTesting instead of mirrors?
   // ignore: avoid_dynamic_calls
-  return (reflect(connection).getField(oidCacheMirror.simpleName).reflectee)
+  return reflect(connection)
+      .getField(oidCacheMirror.simpleName)
+      .reflectee
       .queryCount as int;
 }


### PR DESCRIPTION
Adding:
  - unnecessary_null_checks
  - unnecessary_parenthesis
  - unnecessary_raw_strings Each of these found real cases where fixing with the lint improved readability (one could argue about the raw strings).