### PR TITLE
chore: add use_raw_strings and use_super_parameters

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -57,5 +57,7 @@ linter:
   - unnecessary_statements
   - unnecessary_this
   - unrelated_type_equality_checks
+  - use_raw_strings
   - use_rethrow_when_possible
+  - use_super_parameters
   - valid_regexps

--- a/lib/src/auth/clear_text_authenticator.dart
+++ b/lib/src/auth/clear_text_authenticator.dart
@@ -6,7 +6,7 @@ import '../utf8_backed_string.dart';
 import 'auth.dart';
 
 class ClearAuthenticator extends PostgresAuthenticator {
-  ClearAuthenticator(PostgresAuthConnection connection) : super(connection);
+  ClearAuthenticator(super.connection);
 
   @override
   void onMessage(AuthenticationMessage message) {

--- a/lib/src/auth/md5_authenticator.dart
+++ b/lib/src/auth/md5_authenticator.dart
@@ -9,7 +9,7 @@ import 'auth.dart';
 class MD5Authenticator extends PostgresAuthenticator {
   static final String name = 'MD5';
 
-  MD5Authenticator(PostgresAuthConnection connection) : super(connection);
+  MD5Authenticator(super.connection);
 
   @override
   void onMessage(AuthenticationMessage message) {

--- a/lib/src/auth/sasl_authenticator.dart
+++ b/lib/src/auth/sasl_authenticator.dart
@@ -13,9 +13,7 @@ import 'auth.dart';
 class PostgresSaslAuthenticator extends PostgresAuthenticator {
   final SaslAuthenticator authenticator;
 
-  PostgresSaslAuthenticator(
-      PostgresAuthConnection connection, this.authenticator)
-      : super(connection);
+  PostgresSaslAuthenticator(super.connection, this.authenticator);
 
   @override
   void onMessage(AuthenticationMessage message) {

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -548,11 +548,11 @@ void main() {
           utf8.encode(encoder.convert("''")), equals([39, 39, 39, 39, 39, 39]));
 
       //                                                       sp   E   '   \   \   '   '   '   '   '
-      expect(utf8.encode(encoder.convert("\\''")),
+      expect(utf8.encode(encoder.convert(r"\''")),
           equals([32, 69, 39, 92, 92, 39, 39, 39, 39, 39]));
 
       //                                                      sp   E   '   \   \   '   '   '
-      expect(utf8.encode(encoder.convert("\\'")),
+      expect(utf8.encode(encoder.convert(r"\'")),
           equals([32, 69, 39, 92, 92, 39, 39, 39]));
     });
 

--- a/test/interpolation_test.dart
+++ b/test/interpolation_test.dart
@@ -102,16 +102,16 @@ void main() {
   });
 
   test('UTF16 symbols with backslash', () {
-    final value = "'©\\™®'";
+    final value = r"'©\™®'";
     final results = PostgreSQLFormat.substitute(
         'INSERT INTO t (t) VALUES (@t)', {'t': value});
 
-    expect(results, "INSERT INTO t (t) VALUES ( E'''©\\\\™®''')");
+    expect(results, r"INSERT INTO t (t) VALUES ( E'''©\\™®''')");
   });
 
   test('String identifiers get escaped', () {
     final result = PostgreSQLFormat.substitute(
-        '@id:text @foo', {'id': "1';select", 'foo': '3\\4'});
+        '@id:text @foo', {'id': "1';select", 'foo': r'3\4'});
 
     //                         '  1  '  '  ;  s   e   l   e   c  t   '  sp  sp  E  '  3  \  \  4  '
     expect(utf8.encode(result), [

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -79,10 +79,10 @@ void main() {
           'INSERT INTO t (t) values '
           '(${PostgreSQLFormat.id('t', type: PostgreSQLDataType.text)})',
           substitutionValues: {
-            't': "°\\'©™®'",
+            't': r"°\'©™®'",
           });
 
-      final expectedRow = ["°\\'©™®'"];
+      final expectedRow = [r"°\'©™®'"];
 
       final result = await connection.query('select t from t');
       expect(result, [expectedRow]);


### PR DESCRIPTION
The super parameters change is an obvious win, the raw strings change is debatable, but I think it still makes at least the short strings more readable.