### PR TITLE
feat: let `PgStatement.run` parameters be optional positional (v3)

### DIFF
--- a/example/v3/example.dart
+++ b/example/v3/example.dart
@@ -7,7 +7,7 @@ void main() async {
 
   final statement = await connection.prepare(PgSql(r"SELECT 'foo';"));
   print('has statement');
-  final result = await statement.run(null);
+  final result = await statement.run();
   print(result);
   await statement.dispose();
 

--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -186,9 +186,10 @@ abstract class PgStatement {
       Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */
           parameters);
 
-  Future<PgResult> run(
+  Future<PgResult> run([
     Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */
         parameters,
+  ]
   ) async {
     final items = <PgResultRow>[];
     final subscription = bind(parameters).listen(items.add);

--- a/lib/src/v3/pool.dart
+++ b/lib/src/v3/pool.dart
@@ -202,7 +202,7 @@ class _PoolStatement implements PgStatement {
   }
 
   @override
-  Future<PgResult> run(Object? parameters) {
+  Future<PgResult> run([Object? parameters]) {
     return _underlying.run(parameters);
   }
 }


### PR DESCRIPTION
I believe there's no reason to force the user to add `null` as a parameter as it was shown in the example:

- before
  ```dart
    final result = await statement.run(null);
  ```

- after
  ```dart
    final result = await statement.run();
  ```


_let me know if I need to add a changelog entry or if you prefer to publish this with other changes later_ 