### PR TITLE
feat: allow explicit use of Simple Query Protocol (v3)

### DIFF
--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -133,7 +133,6 @@ abstract class PgSession {
   /// When [useSimpleQueryProtocol] is set to true, the implementation will use
   /// the Simple Query Protocol. Please note, a query with [parameters] cannot
   /// be used with this protocol. 
-  /// 
   Future<PgResult> execute(
     Object /* String | PgSql */ query, {
     Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */

--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -129,11 +129,17 @@ abstract class PgSession {
   /// optimization can be applied also depends on the parameters chosen, so
   /// there is no guarantee that the [PgResult] from a [ignoreRows] excution has
   /// no rows.
+  /// 
+  /// When [useSimpleQueryProtocol] is set to true, the implementation will use
+  /// the Simple Query Protocol. Please note, a query with [parameters] cannot
+  /// be used with this protocol. 
+  /// 
   Future<PgResult> execute(
     Object /* String | PgSql */ query, {
     Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */
         parameters,
     bool ignoreRows = false,
+    bool useSimpleQueryProtocol = false,
   });
 
   /// Closes this session, cleaning up resources and forbiding further calls to

--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -130,15 +130,16 @@ abstract class PgSession {
   /// there is no guarantee that the [PgResult] from a [ignoreRows] excution has
   /// no rows.
   /// 
-  /// When [useSimpleQueryProtocol] is set to true, the implementation will use
-  /// the Simple Query Protocol. Please note, a query with [parameters] cannot
-  /// be used with this protocol. 
+  /// [queryMode] is optional to override the default query execution mode that 
+  /// is defined in [PgSessionSettings]. Unless necessary, always prefer using 
+  /// [QueryMode.extended] which is the default value. For more information,
+  /// see [PgSessionSettings.queryMode]
   Future<PgResult> execute(
     Object /* String | PgSql */ query, {
     Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */
         parameters,
     bool ignoreRows = false,
-    bool useSimpleQueryProtocol = false,
+    QueryMode? queryMode,
   });
 
   /// Closes this session, cleaning up resources and forbiding further calls to
@@ -381,6 +382,15 @@ final class PgSessionSettings {
   /// [Streaming Replication Protocol]: https://www.postgresql.org/docs/current/protocol-replication.html
   final ReplicationMode replicationMode;
 
+  /// The Query Execution Mode 
+  /// 
+  /// The default value is [QueryMode.extended] which uses the Extended Query
+  /// Protocol. In certain cases, the Extended protocol cannot be used 
+  /// (e.g. in replication mode or with proxies such as PGBouncer), hence the
+  /// the Simple one would be the only viable option. Unless necessary, always 
+  /// prefer using [QueryMode.extended].
+  final QueryMode queryMode;
+
   PgSessionSettings({
     this.connectTimeout,
     this.timeZone,
@@ -388,6 +398,7 @@ final class PgSessionSettings {
     this.onBadSslCertificate,
     this.transformer,
     this.replicationMode = ReplicationMode.none,
+    this.queryMode = QueryMode.extended,
   });
 }
 
@@ -397,4 +408,12 @@ final class PgPoolSettings {
   const PgPoolSettings({
     this.maxConnectionCount,
   });
+}
+
+/// Options for the Query Execution Mode
+enum QueryMode {
+  /// Extended Query Protocol
+  extended,
+  /// Simple Query Protocol 
+  simple,
 }

--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -242,7 +242,12 @@ class PostgresTextDecoder<T extends Object> {
       case PgDataType.double:
         return num.parse(asText) as T;
       case PgDataType.boolean:
-        return (asText == 'true') as T;
+        // In text data format when using simple query protocol, "true" & "false"
+        // are represented as `t` and `f`,  respectively. 
+        // we will check for both just in case
+        // TODO: should we check for other representations (e.g. `1`, `on`, `y`,
+        // and `yes`)?
+        return (asText == 't' || asText == 'true') as T;
 
       // We could list out all cases, but it's about 20 lines of code.
       // ignore: no_default_cases

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -125,18 +125,18 @@ abstract class _PgSessionBase implements PgSession {
     final description = InternalQueryDescription.wrap(query);
     final variables = description.bindParameters(parameters);
 
-    if (useSimpleQueryProtocol || (ignoreRows && !variables.isNotEmpty)) {
+    if (useSimpleQueryProtocol || (ignoreRows && variables.isEmpty)) {
       // Great, we can just run a simple query.
       final controller = StreamController<PgResultRow>();
       final items = <PgResultRow>[];
 
-      final querySubscription =
-          _PgResultStreamSubscription.simpleQueryProtocol(
-              description.transformedSql,
-              this,
-              controller,
-              controller.stream.listen(items.add),
-              ignoreRows);
+      final querySubscription = _PgResultStreamSubscription.simpleQueryProtocol(
+        description.transformedSql,
+        this,
+        controller,
+        controller.stream.listen(items.add),
+        ignoreRows,
+      );
       await querySubscription.asFuture();
       await querySubscription.cancel();
 

--- a/lib/src/v3/pool.dart
+++ b/lib/src/v3/pool.dart
@@ -42,12 +42,17 @@ class PoolImplementation implements PgPool {
   }
 
   @override
-  Future<PgResult> execute(Object query,
-      {Object? parameters, bool ignoreRows = false}) {
+  Future<PgResult> execute(
+    Object query, {
+    Object? parameters,
+    bool ignoreRows = false,
+    bool useSimpleQueryProtocol = false,
+  }) {
     return withConnection((connection) => connection.execute(
           query,
           parameters: parameters,
           ignoreRows: ignoreRows,
+          useSimpleQueryProtocol: useSimpleQueryProtocol,
         ));
   }
 
@@ -161,12 +166,17 @@ class _PoolConnection implements PgConnection {
   }
 
   @override
-  Future<PgResult> execute(Object query,
-      {Object? parameters, bool ignoreRows = false}) {
+  Future<PgResult> execute(
+    Object query, {
+    Object? parameters,
+    bool ignoreRows = false,
+    bool useSimpleQueryProtocol = false,
+  }) {
     return _connection.execute(
       query,
       parameters: parameters,
       ignoreRows: ignoreRows,
+      useSimpleQueryProtocol: useSimpleQueryProtocol,
     );
   }
 

--- a/lib/src/v3/pool.dart
+++ b/lib/src/v3/pool.dart
@@ -46,13 +46,13 @@ class PoolImplementation implements PgPool {
     Object query, {
     Object? parameters,
     bool ignoreRows = false,
-    bool useSimpleQueryProtocol = false,
+    QueryMode? queryMode,
   }) {
     return withConnection((connection) => connection.execute(
           query,
           parameters: parameters,
           ignoreRows: ignoreRows,
-          useSimpleQueryProtocol: useSimpleQueryProtocol,
+          queryMode: queryMode,
         ));
   }
 
@@ -170,13 +170,13 @@ class _PoolConnection implements PgConnection {
     Object query, {
     Object? parameters,
     bool ignoreRows = false,
-    bool useSimpleQueryProtocol = false,
+    QueryMode? queryMode,
   }) {
     return _connection.execute(
       query,
       parameters: parameters,
       ignoreRows: ignoreRows,
-      useSimpleQueryProtocol: useSimpleQueryProtocol,
+      queryMode: queryMode,
     );
   }
 

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -402,6 +402,29 @@ void main() {
         expect(await connection.execute('SELECT id FROM t'), isEmpty);
       });
     });
+
+    group('Simple Query Protocol', () {
+      test('single simple query', () async {
+        final res = await connection.execute(
+          "SELECT 'dart', 42, true, false, NULL",
+          queryMode: QueryMode.simple,
+        );
+        expect(res, [
+          ['dart', 42, true, false, null]
+        ]);
+      });
+
+      test('parameterized query throws', () async {
+        await expectLater(
+          () => connection.execute(
+            r'SELECT 1',
+            parameters: [PgTypedParameter(PgDataType.integer, 1)],
+            queryMode: QueryMode.simple
+          ),
+          _throwsPostgresException,
+        );
+      });
+    });
   });
 
   test('can inject transformer into connection', () async {


### PR DESCRIPTION
The Simple Query Protocol is the only protocol that can be used when the connection is in Replication Mode in order to query system information such as `IDENTIFY_SYSTEM;` query.

Currently, the only way to use the Simple Protocol is to set `ignoreRows`  to `true` but this will return no result and there's no way around it. 

While taking @simolus3 comment from PR #102 into consideration, I added an option to explicit use the Simple Query Protocol. In addition, it is used when there are no parameters and `ignoreRows` is set to true. 
