### PR TITLE
Fix decoding numeric values

### DIFF
--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -439,8 +439,12 @@ class PostgresBinaryEncoder<T extends Object>
 }
 
 class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
-  const PostgresBinaryDecoder(this.typeCode);
+  const PostgresBinaryDecoder(this.typeCode) : type = null;
 
+  PostgresBinaryDecoder.byType(PgDataType this.type)
+      : typeCode = type.oid ?? -1;
+
+  final PgDataType? type;
   final int typeCode;
 
   @override
@@ -449,7 +453,7 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
       return null;
     }
 
-    final dataType = typeMap[typeCode];
+    final dataType = type ?? typeMap[typeCode];
 
     final buffer =
         ByteData.view(input.buffer, input.offsetInBytes, input.lengthInBytes);

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -439,13 +439,9 @@ class PostgresBinaryEncoder<T extends Object>
 }
 
 class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
-  const PostgresBinaryDecoder(this.typeCode) : type = null;
+  PostgresBinaryDecoder(this.type);
 
-  PostgresBinaryDecoder.byType(PgDataType this.type)
-      : typeCode = type.oid ?? -1;
-
-  final PgDataType? type;
-  final int typeCode;
+  final PgDataType type;
 
   @override
   T? convert(Uint8List? input) {
@@ -453,12 +449,10 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
       return null;
     }
 
-    final dataType = type ?? typeMap[typeCode];
-
     final buffer =
         ByteData.view(input.buffer, input.offsetInBytes, input.lengthInBytes);
 
-    switch (dataType) {
+    switch (type) {
       case PostgreSQLDataType.name:
       case PostgreSQLDataType.text:
       case PostgreSQLDataType.varChar:
@@ -566,8 +560,6 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
         }) as T;
 
       case PostgreSQLDataType.unknownType:
-      // TODO(eseidel): This looks wrong for null?
-      case null:
         {
           // We'll try and decode this as a utf8 string and return that
           // for many internal types, this is valid. If it fails,

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -298,7 +298,9 @@ class FieldDescription implements ColumnDescription {
     final typeModifier = reader.readInt32();
     final formatCode = reader.readUint16();
 
-    final converter = PostgresBinaryDecoder(typeOid);
+    final converter = PostgresBinaryDecoder(
+        PostgreSQLDataType.byTypeOid[typeOid] ??
+            PostgreSQLDataType.unknownType);
     return FieldDescription._(
       converter, fieldName, tableID, columnID, typeOid,
       dataTypeSize, typeModifier, formatCode,

--- a/lib/src/v3/types.dart
+++ b/lib/src/v3/types.dart
@@ -189,7 +189,7 @@ class _BinaryTypeCodec<D extends Object> extends Codec<D?, Uint8List?> {
 
   _BinaryTypeCodec(PgDataType<D> type)
       : encoder = PostgresBinaryEncoder(type),
-        decoder = PostgresBinaryDecoder.byType(type);
+        decoder = PostgresBinaryDecoder(type);
 }
 
 class _TextTypeCodec<D extends Object> extends Codec<D?, Uint8List?> {

--- a/lib/src/v3/types.dart
+++ b/lib/src/v3/types.dart
@@ -69,8 +69,12 @@ enum PgDataType<Dart extends Object> {
   /// Must be a [Duration]
   interval<Duration>(1186, nameForSubstitution: 'interval'),
 
-  /// Must be a [List<int>]
-  numeric<List<int>>(1700, nameForSubstitution: 'numeric'),
+  /// An arbitrary-precision number.
+  ///
+  /// This library supports encoding numbers in a textual format, or when
+  /// passed as [int] or [double]. When decoding values, numeric types are
+  /// always returned as string.
+  numeric<Object>(1700, nameForSubstitution: 'numeric'),
 
   /// Must be a [DateTime] (contains year, month and day only)
   date<DateTime>(1082, nameForSubstitution: 'date'),
@@ -185,9 +189,7 @@ class _BinaryTypeCodec<D extends Object> extends Codec<D?, Uint8List?> {
 
   _BinaryTypeCodec(PgDataType<D> type)
       : encoder = PostgresBinaryEncoder(type),
-        // Only some integer variants have no dedicated oid, they share it with
-        // the normal integer.
-        decoder = PostgresBinaryDecoder(type.oid ?? PgDataType.integer.oid!);
+        decoder = PostgresBinaryDecoder.byType(type);
 }
 
 class _TextTypeCodec<D extends Object> extends Codec<D?, Uint8List?> {

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -232,7 +232,7 @@ void main() {
       '0.0': [0, 0, 0, 0, 0, 0, 0, 1], // .0 or 0.0
     };
 
-    final decoder = PostgresBinaryDecoder(1700);
+    final decoder = PostgresBinaryDecoder(PostgreSQLDataType.numeric);
     binaries.forEach((key, value) {
       final uint8List = Uint8List.fromList(value);
       final res = decoder.convert(uint8List);

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -692,14 +692,8 @@ Future expectInverse(dynamic value, PostgreSQLDataType dataType) async {
   } else if (dataType == PostgreSQLDataType.bigSerial) {
     dataType = PostgreSQLDataType.bigInteger;
   }
-  late int code;
-  PostgresBinaryDecoder.typeMap.forEach((key, type) {
-    if (type == dataType) {
-      code = key;
-    }
-  });
 
-  final decoder = PostgresBinaryDecoder(code);
+  final decoder = PostgresBinaryDecoder(dataType);
   final decodedValue = decoder.convert(encodedValue);
 
   expect(decodedValue, value);


### PR DESCRIPTION
`PgDataType.numeric` is instantiated with the `List<int>` type parameter. I think this is wrong, the parameter must have been taken from the comment by mistake.

Looking at the implementation for `numeric` in the binary encoder and decoder, it seems like we support encoding these values from ints, doubles and strings. But we're always decoding them as strings. Since these types share no common interface, the type need to be declared as `Object` to avoid the `as T` in the decoder failing.

I've also added a constructor directly taking a type to avoid the double lookup from and to oids.