### PR TITLE
Optimize json encoding and decoding

### DIFF
--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -185,17 +185,11 @@ class PostgresBinaryEncoder<T extends Object>
 
       case PgDataType.jsonb:
         {
-          late Uint8List bytes;
-          final sink = ByteConversionSink.withCallback((accumulated) {
-            bytes = castBytes(accumulated);
-          });
-          sink.add([1]);
-
-          _jsonUtf8.encoder.startChunkedConversion(sink)
-            ..add(input)
-            ..close();
-
-          return bytes;
+          final jsonBytes = _jsonUtf8.encode(input);
+          final writer = ByteDataWriter(bufferLength: jsonBytes.length + 1);
+          writer.writeUint8(1);
+          writer.write(jsonBytes);
+          return writer.toBytes();
         }
 
       case PgDataType.json:

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -185,11 +185,17 @@ class PostgresBinaryEncoder<T extends Object>
 
       case PgDataType.jsonb:
         {
-          final jsonBytes = _jsonUtf8.encode(input);
-          final writer = ByteDataWriter(bufferLength: jsonBytes.length + 1)
-            ..writeUint8(1)
-            ..write(jsonBytes);
-          return writer.toBytes();
+          late Uint8List bytes;
+          final sink = ByteConversionSink.withCallback((accumulated) {
+            bytes = castBytes(accumulated);
+          });
+          sink.add([1]);
+
+          _jsonUtf8.encoder.startChunkedConversion(sink)
+            ..add(input)
+            ..close();
+
+          return bytes;
         }
 
       case PgDataType.json:

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -31,6 +31,10 @@ final _numericRegExp = RegExp(r'^(\d*)(\.\d*)?$');
 final _leadingZerosRegExp = RegExp('^0+');
 final _trailingZerosRegExp = RegExp(r'0+$');
 
+// The Dart SDK provides an optimized implementation for JSON from and to UTF-8
+// that doesn't allocate intermediate strings.
+final _jsonUtf8 = json.fuse(utf8);
+
 class PostgresBinaryEncoder<T extends Object>
     extends Converter<T?, Uint8List?> {
   final PgDataType<T> _dataType;
@@ -181,15 +185,15 @@ class PostgresBinaryEncoder<T extends Object>
 
       case PgDataType.jsonb:
         {
-          final jsonBytes = utf8.encode(json.encode(input));
-          final writer = ByteDataWriter(bufferLength: jsonBytes.length + 1);
-          writer.writeUint8(1);
-          writer.write(jsonBytes);
+          final jsonBytes = _jsonUtf8.encode(input);
+          final writer = ByteDataWriter(bufferLength: jsonBytes.length + 1)
+            ..writeUint8(1)
+            ..write(jsonBytes);
           return writer.toBytes();
         }
 
       case PgDataType.json:
-        return castBytes(utf8.encode(json.encode(input)));
+        return castBytes(_jsonUtf8.encode(input));
 
       case PgDataType.byteArray:
         {
@@ -324,7 +328,7 @@ class PostgresBinaryEncoder<T extends Object>
       case PgDataType.jsonbArray:
         {
           if (input is List<Object>) {
-            final objectsArray = input.map((v) => utf8.encode(json.encode(v)));
+            final objectsArray = input.map(_jsonUtf8.encode);
             return writeListBytes<List<int>>(
                 objectsArray, 3802, (item) => item.length + 1, (writer, item) {
               writer.writeUint8(1);
@@ -495,11 +499,11 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
           // Removes version which is first character and currently always '1'
           final bytes = input.buffer
               .asUint8List(input.offsetInBytes + 1, input.lengthInBytes - 1);
-          return json.decode(utf8.decode(bytes)) as T;
+          return _jsonUtf8.decode(bytes) as T;
         }
 
       case PostgreSQLDataType.json:
-        return json.decode(utf8.decode(input)) as T;
+        return _jsonUtf8.decode(input) as T;
 
       case PostgreSQLDataType.byteArray:
         return input as T;
@@ -558,7 +562,7 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
         return readListBytes<dynamic>(input, (reader, length) {
           reader.read(1);
           final bytes = reader.read(length - 1);
-          return json.decode(utf8.decode(bytes));
+          return _jsonUtf8.decode(bytes);
         }) as T;
 
       case PostgreSQLDataType.unknownType:


### PR DESCRIPTION
The Dart SDK, or at least the VM implementation, contains an optimized encoding and decoding pipeline for json to utf8 bytes. By using that instead of chaining the encoders/decoders manually, we can avoid the intermediate strings and make these operations slightly faster.