### PR TITLE
Remove codec properties from PgDataType.

### DIFF
--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -36,14 +36,12 @@ final _trailingZerosRegExp = RegExp(r'0+$');
 // that doesn't allocate intermediate strings.
 final _jsonUtf8 = json.fuse(utf8);
 
-class PostgresBinaryEncoder<T extends Object>
-    extends Converter<T?, Uint8List?> {
+class PostgresBinaryEncoder<T extends Object> {
   final PgDataType<T> _dataType;
 
   const PostgresBinaryEncoder(this._dataType);
 
-  @override
-  Uint8List? convert(Object? input) {
+  Uint8List? convert(Object? input, Encoding encoding) {
     if (input == null) {
       return null;
     }
@@ -98,7 +96,7 @@ class PostgresBinaryEncoder<T extends Object>
       case PgDataType.varChar:
         {
           if (input is String) {
-            return castBytes(utf8.encode(input));
+            return castBytes(encoding.encode(input));
           }
           throw FormatException(
               'Invalid type for parameter value. Expected: String Got: ${input.runtimeType}');
@@ -443,13 +441,12 @@ class PostgresBinaryEncoder<T extends Object>
   }
 }
 
-class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
+class PostgresBinaryDecoder<T> {
   PostgresBinaryDecoder(this.type);
 
   final PgDataType type;
 
-  @override
-  T? convert(Uint8List? input) {
+  T? convert(Uint8List? input, Encoding encoding) {
     if (input == null) {
       return null;
     }
@@ -461,7 +458,7 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
       case PostgreSQLDataType.name:
       case PostgreSQLDataType.text:
       case PostgreSQLDataType.varChar:
-        return utf8.decode(input) as T;
+        return encoding.decode(input) as T;
       case PostgreSQLDataType.boolean:
         return (buffer.getInt8(0) != 0) as T;
       case PostgreSQLDataType.smallInteger:
@@ -550,7 +547,7 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
       case PostgreSQLDataType.varCharArray:
       case PostgreSQLDataType.textArray:
         return readListBytes<String>(input, (reader, length) {
-          return utf8.decode(length > 0 ? reader.read(length) : []);
+          return encoding.decode(length > 0 ? reader.read(length) : []);
         }) as T;
 
       case PostgreSQLDataType.doubleArray:
@@ -571,7 +568,7 @@ class PostgresBinaryDecoder<T> extends Converter<Uint8List?, T?> {
           // we just return the bytes and let the caller figure out what to
           // do with it.
           try {
-            return utf8.decode(input) as T;
+            return encoding.decode(input) as T;
           } catch (_) {
             return input as T;
           }

--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -13,17 +13,17 @@ class EncodedString {
 }
 
 class PgByteDataWriter extends ByteDataWriter {
-  final Encoding _encoding;
+  final Encoding encoding;
 
   PgByteDataWriter({
     super.bufferLength,
-    Encoding encoding = utf8,
-  }) : _encoding = encoding;
+    this.encoding = utf8,
+  });
 
-  late final encodingName = encodeString(_encoding.name);
+  late final encodingName = encodeString(encoding.name);
 
   EncodedString encodeString(String value) {
-    return EncodedString._(_encoding.encode(value));
+    return EncodedString._(encoding.encode(value));
   }
 
   void writeEncodedString(EncodedString value) {

--- a/lib/src/client_messages.dart
+++ b/lib/src/client_messages.dart
@@ -191,7 +191,8 @@ class BindMessage extends ClientMessage {
     final portalName = buffer.encodeString(_portalName);
     final statementName = buffer.encodeString(_statementName);
 
-    final parameterBytes = _parameters.map((p) => p.encodeAsBytes()).toList();
+    final parameterBytes =
+        _parameters.map((p) => p.encodeAsBytes(buffer.encoding)).toList();
     final typeSpecCount = _parameters.where((p) => p.hasKnownType).length;
     var inputParameterElementCount = _parameters.length;
     if (typeSpecCount == _parameters.length || typeSpecCount == 0) {

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -166,7 +166,7 @@ class Query<T> {
     final iterator = fieldDescriptions!.iterator;
     final lazyDecodedData = rawRowData.map((bd) {
       iterator.moveNext();
-      return iterator.current.converter.convert(bd);
+      return iterator.current.converter.convert(bd, utf8);
     });
 
     rows.add(lazyDecodedData.toList());
@@ -232,21 +232,22 @@ class ParameterValue {
 
   bool get hasKnownType => _type != null;
 
-  Uint8List? encodeAsBytes() {
+  Uint8List? encodeAsBytes(Encoding encoding) {
     if (_type != null) {
-      return _type!.binaryCodec.encoder.convert(_value);
+      final encoder = PostgresBinaryEncoder(_type!);
+      return encoder.convert(_value, encoding);
     }
     if (_value != null) {
       const converter = PostgresTextEncoder();
       return castBytes(
-          utf8.encode(converter.convert(_value, escapeStrings: false)));
+          encoding.encode(converter.convert(_value, escapeStrings: false)));
     }
     return null;
   }
 }
 
 class FieldDescription implements ColumnDescription {
-  final Converter converter;
+  final PostgresBinaryDecoder converter;
 
   @override
   final String columnName;

--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -218,16 +218,15 @@ class PostgresTextEncoder extends Converter<Object, String> {
   }
 }
 
-class PostgresTextDecoder<T extends Object> extends Converter<Uint8List?, T?> {
+class PostgresTextDecoder<T extends Object> {
   final PgDataType<T> _dataType;
 
   const PostgresTextDecoder(this._dataType);
 
-  @override
-  T? convert(Uint8List? input) {
+  T? convert(Uint8List? input, Encoding encoding) {
     if (input == null) return null;
 
-    final asText = utf8.decode(input);
+    final asText = encoding.decode(input);
 
     // ignore: unnecessary_cast
     switch (_dataType as PgDataType<Object>) {

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:postgres/postgres.dart';
@@ -235,7 +236,7 @@ void main() {
     final decoder = PostgresBinaryDecoder(PostgreSQLDataType.numeric);
     binaries.forEach((key, value) {
       final uint8List = Uint8List.fromList(value);
-      final res = decoder.convert(uint8List);
+      final res = decoder.convert(uint8List, utf8);
       expect(res, key);
     });
   });

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -253,7 +253,7 @@ void main() {
       final encoder = PostgresBinaryEncoder<Object>(PostgreSQLDataType.numeric);
       binaries.forEach((key, value) {
         final uint8List = Uint8List.fromList(value);
-        final res = encoder.convert(key);
+        final res = encoder.convert(key, utf8);
         expect(res, uint8List);
       });
 
@@ -502,7 +502,8 @@ void main() {
       ]);
 
       expect(
-        () => PostgresBinaryEncoder(PostgreSQLDataType.voidType).convert(1),
+        () =>
+            PostgresBinaryEncoder(PostgreSQLDataType.voidType).convert(1, utf8),
         throwsArgumentError,
       );
     });
@@ -633,28 +634,28 @@ void main() {
   test('Invalid UUID encoding', () {
     final converter = PostgresBinaryEncoder<Object>(PostgreSQLDataType.uuid);
     try {
-      converter.convert('z0000000-0000-0000-0000-000000000000');
+      converter.convert('z0000000-0000-0000-0000-000000000000', utf8);
       fail('unreachable');
     } on FormatException catch (e) {
       expect(e.toString(), contains('Invalid UUID string'));
     }
 
     try {
-      converter.convert(123123);
+      converter.convert(123123, utf8);
       fail('unreachable');
     } on FormatException catch (e) {
       expect(e.toString(), contains('Invalid type for parameter'));
     }
 
     try {
-      converter.convert('0000000-0000-0000-0000-000000000000');
+      converter.convert('0000000-0000-0000-0000-000000000000', utf8);
       fail('unreachable');
     } on FormatException catch (e) {
       expect(e.toString(), contains('Invalid UUID string'));
     }
 
     try {
-      converter.convert('00000000-0000-0000-0000-000000000000f');
+      converter.convert('00000000-0000-0000-0000-000000000000f', utf8);
       fail('unreachable');
     } on FormatException catch (e) {
       expect(e.toString(), contains('Invalid UUID string'));
@@ -672,7 +673,7 @@ Future expectInverse(dynamic value, PostgreSQLDataType dataType) async {
   expect(result.first.first, equals(value));
 
   final encoder = PostgresBinaryEncoder(dataType);
-  final encodedValue = encoder.convert(value);
+  final encodedValue = encoder.convert(value, utf8);
 
   if (dataType == PostgreSQLDataType.serial) {
     dataType = PostgreSQLDataType.integer;
@@ -681,7 +682,7 @@ Future expectInverse(dynamic value, PostgreSQLDataType dataType) async {
   }
 
   final decoder = PostgresBinaryDecoder(dataType);
-  final decodedValue = decoder.convert(encodedValue);
+  final decodedValue = decoder.convert(encodedValue, utf8);
 
   expect(decodedValue, value);
 }


### PR DESCRIPTION
- Instead of that caching we should have fewer places with `switch` statements.
- Makes the encoding explicit in more convert methods.