### PR TITLE
fix: handle PgDataType.voidType

### DIFF
--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -257,7 +257,10 @@ class PostgresTextDecoder<T extends Object> {
       // TODO: implement the rest of the types 
       // ignore: no_default_cases
       default:
-        return asText as T;
+        if (asText is T) {
+          return asText as T;
+        }
+        throw UnimplementedError('Text decoding for $_dataType');
     }
   }
 }

--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -248,11 +248,16 @@ class PostgresTextDecoder<T extends Object> {
         // TODO: should we check for other representations (e.g. `1`, `on`, `y`,
         // and `yes`)?
         return (asText == 't' || asText == 'true') as T;
+      
+      case PgDataType.voidType:
+        // TODO: is returning `null` here is the appripriate thing to do? 
+        return null;
 
       // We could list out all cases, but it's about 20 lines of code.
+      // TODO: implement the rest of the types 
       // ignore: no_default_cases
       default:
-        throw UnimplementedError('Text decoding for $_dataType');
+        return asText as T;
     }
   }
 }


### PR DESCRIPTION
Partly fixes #125

- For `PgDataType.voidType`, return `null`. 
- For any unimplemented type, return whatever was decoded as text 
  -  I believe it's better to return something than throw an exception 

----
Context:

I was running this query and I received the following error:

```
--> data ReadyForQueryMessage(state = I)
<-- data Instance of 'QueryMessage'
      sending Qnselect pg_drop_replication_slot('a_test_slot') from pg_replication_slots where slot_name = 'a_test_slot';
--> data Instance of 'RowDescriptionMessage'
--> data Data Row Message: [[]]
Unhandled exception:
UnimplementedError: Text decoding for PgDataType.voidType
```