### PR TITLE
chore: remove unncessary print in tests

### DIFF
--- a/test/error_handling_test.dart
+++ b/test/error_handling_test.dart
@@ -29,7 +29,6 @@ void main() {
         await conn.execute('DELETE FROM hello');
         fail('Should not reach');
       } catch (e, st) {
-        print(e);
         expect(e.toString(), contains('relation "hello" does not exist'));
         expect(
           st.toString(),


### PR DESCRIPTION
This print statement shows "an error" message in the test logs which was confusing


_btw, thanks for #145 -- tests now run much faster locally_ 