### PR TITLE
Migrate transaction tests to v3

### DIFF
--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -106,23 +106,27 @@ class PgSql {
 abstract class PgSession {
   /// Prepares a reusable statement from a [query].
   ///
-  /// Query can either be a string or a [PgSql] instance. The [query] value used
-  /// alters the behavior of [PgStatement.bind]: When a string is used, the
-  /// query is sent to Postgres without modification and you may only used
-  /// indexed parameters (e.g. `SELECT * FROM users WHERE id = $1`). When using
-  /// [PgSql.map], you can use named parameters as well (e.g. `WHERE id = @id`).
+  /// [query] must either be a [String] or a [PgSql] object with types for
+  /// parameters already set. If the types for parameters are already known from
+  /// the query, a direct list of values can be passed for [parameters].
+  /// Otherwise, the type of parameter types must be made explicit. This can be
+  /// done by passing [PgTypedParameter] objects in a list, or (if a string or
+  /// [PgSql.map] value is passed for [query]), via the names of declared
+  /// statements.
   ///
   /// When the returned future completes, the statement must eventually be freed
-  /// using [PgStatement.close] to avoid resource leaks.
+  /// using [PgStatement.dispose] to avoid resource leaks.
   Future<PgStatement> prepare(Object /* String | PgSql */ query);
 
   /// Executes the [query] with the given [parameters].
   ///
-  /// [query] must either be a [String] or a [PgSql] query with types for
-  /// parameters. When a [PgSql] query object with known types is used,
-  /// [parameters] can be a list of direct values. Otherwise, it must be a list
-  /// of [PgTypedParameter]s. With [PgSql.map], values can also be provided as a
-  /// map from the substituted parameter keys to objects or [PgTypedParameter]s.
+  /// [query] must either be a [String] or a [PgSql] object with types for
+  /// parameters already set. If the types for parameters are already known from
+  /// the query, a direct list of values can be passed for [parameters].
+  /// Otherwise, the type of parameter types must be made explicit. This can be
+  /// done by passing [PgTypedParameter] objects in a list, or (if a string or
+  /// [PgSql.map] value is passed for [query]), via the names of declared
+  /// statements.
   ///
   /// When [ignoreRows] is set to true, the implementation may internally
   /// optimize the execution to ignore rows returned by the query. Whether this

--- a/lib/src/client_messages.dart
+++ b/lib/src/client_messages.dart
@@ -119,6 +119,11 @@ class QueryMessage extends ClientMessage {
     buffer.writeUint8(ClientMessage.QueryIdentifier);
     buffer.writeLengthEncodedString(_queryString);
   }
+
+  @override
+  String toString() {
+    return 'Query: $_queryString';
+  }
 }
 
 class ParseMessage extends ClientMessage {
@@ -151,6 +156,11 @@ class ParseMessage extends ClientMessage {
     for (final type in _types) {
       buffer.writeInt32(type?.oid ?? 0);
     }
+  }
+
+  @override
+  String toString() {
+    return 'Parse $_statement';
   }
 }
 

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -555,11 +555,11 @@ class _PgResultStreamSubscription
   void _scheduleStatement(Future<void> Function() sendAndWait) async {
     try {
       await session._withResource(sendAndWait);
-    } on PostgreSQLException catch (e) {
+    } catch (e, s) {
       // _withResource can fail if the connection or the session is already
       // closed. This error should be reported to the user!
       if (!_done.isCompleted) {
-        handleError(e);
+        _controller.addError(e, s);
         await _completeQuery();
       }
     }

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -385,15 +385,15 @@ class PgConnectionImplementation extends _PgSessionBase
       // The transaction has its own _operationLock, which means that it (and
       // only it) can be used to run statements while it's active.
       final transaction = _TransactionSession(this);
-      await transaction.execute('BEGIN;');
+      await transaction.execute(PgSql('BEGIN;'));
 
       try {
         final result = await fn(transaction);
-        await transaction.execute('COMMIT;');
+        await transaction.execute(PgSql('COMMIT;'));
 
         return result;
       } catch (e) {
-        await transaction.execute('ROLLBACK;');
+        await transaction.execute(PgSql('ROLLBACK;'));
         rethrow;
       }
     });

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -76,24 +76,32 @@ abstract class _PgSessionBase implements PgSession {
   /// connection in the meantime.
   final Pool _operationLock = Pool(1);
 
+  bool _sessionClosed = false;
+
   PgConnectionImplementation get _connection;
   Encoding get encoding => _connection._settings.encoding;
+
+  void _checkActive() {
+    if (_sessionClosed) {
+      throw PostgreSQLException(
+          'Session or transaction has already finished, did you forget to await a statement?');
+    } else if (_connection._isClosing) {
+      throw PostgreSQLException('Connection is closing down');
+    }
+  }
 
   /// Runs [callback], guarded by [_operationLock] and cleans up the pending
   /// resource afterwards.
   Future<T> _withResource<T>(FutureOr<T> Function() callback) {
-    if (_connection._isClosing) {
-      throw PostgreSQLException('Connection is closing down');
-    }
+    _checkActive();
+    return _operationLock.withResource(() {
+      _checkActive();
+      assert(_connection._pending == null,
+          'Previous operation ${_connection._pending} did not clean up.');
 
-    return _operationLock.withResource(() async {
-      assert(_connection._pending == null);
-
-      try {
-        return await callback();
-      } finally {
+      return Future(callback).whenComplete(() {
         _connection._pending = null;
-      }
+      });
     });
   }
 
@@ -303,6 +311,9 @@ class PgConnectionImplementation extends _PgSessionBase
   final _ResolvedSettings _settings;
 
   _PendingOperation? _pending;
+  // Errors happening while a transaction is active will roll back the
+  // transaction and should be reporte to the user.
+  _TransactionSession? _activeTransaction;
 
   final Map<String, String> _parameters = {};
 
@@ -355,6 +366,8 @@ class PgConnectionImplementation extends _PgSessionBase
         if (exception.willAbortConnection || _pending == null) {
           _closeAfterError(exception);
         } else {
+          _connection._activeTransaction?._transactionException = exception;
+
           _pending!.handleError(exception);
         }
       } else if (_pending != null) {
@@ -384,16 +397,27 @@ class PgConnectionImplementation extends _PgSessionBase
     return _operationLock.withResource(() async {
       // The transaction has its own _operationLock, which means that it (and
       // only it) can be used to run statements while it's active.
-      final transaction = _TransactionSession(this);
-      await transaction.execute(PgSql('BEGIN;'));
+      final transaction =
+          _connection._activeTransaction = _TransactionSession(this);
+      await transaction.execute(PgSql('BEGIN;'), queryMode: QueryMode.simple);
 
       try {
         final result = await fn(transaction);
-        await transaction.execute(PgSql('COMMIT;'));
+        await transaction._sendAndMarkClosed('COMMIT;');
+
+        // If we have received an error while the transaction was active, it
+        // will always be rolled back.
+        if (transaction._transactionException
+            case final PostgreSQLException e) {
+          throw e;
+        }
 
         return result;
       } catch (e) {
-        await transaction.execute(PgSql('ROLLBACK;'));
+        if (!transaction._sessionClosed) {
+          await transaction._sendAndMarkClosed('ROLLBACK;');
+        }
+
         rethrow;
       }
     });
@@ -490,7 +514,7 @@ class _PgResultStreamSubscription
       _BoundStatement statement, this._controller, this._source)
       : session = statement.statement._session,
         ignoreRows = false {
-    session._withResource(() async {
+    _scheduleStatement(() async {
       connection._pending = this;
 
       connection._channel.sink.add(AggregatedClientMessage([
@@ -511,14 +535,34 @@ class _PgResultStreamSubscription
     });
   }
 
-  _PgResultStreamSubscription.simpleQueryProtocol(String sql, this.session,
-      this._controller, this._source, this.ignoreRows) {
-    session._withResource(() async {
+  _PgResultStreamSubscription.simpleQueryProtocol(
+    String sql,
+    this.session,
+    this._controller,
+    this._source,
+    this.ignoreRows, {
+    void Function()? cleanup,
+  }) {
+    _scheduleStatement(() async {
       connection._pending = this;
 
       connection._channel.sink.add(QueryMessage(sql));
       await _done.future;
+      cleanup?.call();
     });
+  }
+
+  void _scheduleStatement(Future<void> Function() sendAndWait) async {
+    try {
+      await session._withResource(sendAndWait);
+    } on PostgreSQLException catch (e) {
+      // _withResource can fail if the connection or the session is already
+      // closed. This error should be reported to the user!
+      if (!_done.isCompleted) {
+        handleError(e);
+        await _completeQuery();
+      }
+    }
   }
 
   @override
@@ -749,7 +793,33 @@ class _TransactionSession extends _PgSessionBase {
   @override
   final PgConnectionImplementation _connection;
 
+  PostgreSQLException? _transactionException;
+
   _TransactionSession(this._connection);
+
+  /// Sends the [command] and, before releasing the internal connection lock,
+  /// marks the session as closed.
+  ///
+  /// This prevents other pending operations on the transaction that haven't
+  /// been awaited from running.
+  Future<void> _sendAndMarkClosed(String command) async {
+    final controller = StreamController<PgResultRow>();
+    final items = <PgResultRow>[];
+
+    final querySubscription = _PgResultStreamSubscription.simpleQueryProtocol(
+      command,
+      this,
+      controller,
+      controller.stream.listen(items.add),
+      true,
+      cleanup: () {
+        _sessionClosed = true;
+        _connection._activeTransaction = null;
+      },
+    );
+    await querySubscription.asFuture();
+    await querySubscription.cancel();
+  }
 
   @override
   Future<void> close() async {

--- a/lib/src/v3/query_description.dart
+++ b/lib/src/v3/query_description.dart
@@ -53,9 +53,7 @@ class InternalQueryDescription implements PgSql {
 
   factory InternalQueryDescription.wrap(Object query) {
     if (query is String) {
-      // todo: Determine whether we want to use a direct SQL command by default.
-      // Maybe this should be replaced with .map once implemented.
-      return InternalQueryDescription.direct(query);
+      return InternalQueryDescription.map(query);
     } else if (query is InternalQueryDescription) {
       return query;
     } else {

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -16,7 +16,7 @@ void main() {
 
     setUp(() async {
       pool = PgPool(
-        [await server.endpoint],
+        [await server.endpoint()],
         sessionSettings: _sessionSettings,
       );
 
@@ -84,7 +84,7 @@ void main() {
   withPostgresServer('limit pool connections', (server) {
     test('can limit concurrent connections', () async {
       final pool = PgPool(
-        [await server.endpoint],
+        [await server.endpoint()],
         sessionSettings: _sessionSettings,
         poolSettings: const PgPoolSettings(maxConnectionCount: 2),
       );

--- a/test/v3_close_test.dart
+++ b/test/v3_close_test.dart
@@ -11,7 +11,7 @@ void main() {
 
     setUp(() async {
       conn1 = await PgConnection.open(
-        await server.endpoint,
+        await server.endpoint(),
         sessionSettings: PgSessionSettings(
           onBadSslCertificate: (cert) => true,
           //transformer: _loggingTransformer('c1'),
@@ -19,7 +19,7 @@ void main() {
       );
 
       conn2 = await PgConnection.open(
-        await server.endpoint,
+        await server.endpoint(),
         sessionSettings: PgSessionSettings(
           onBadSslCertificate: (cert) => true,
         ),
@@ -35,7 +35,7 @@ void main() {
       test(
         'with concurrent query: $concurrentQuery',
         () async {
-          final endpoint = await server.endpoint;
+          final endpoint = await server.endpoint();
           final res = await conn2.execute(
               "SELECT pid FROM pg_stat_activity where usename = '${endpoint.username}';");
           final conn1PID = res.first.first as int;
@@ -54,7 +54,7 @@ void main() {
     }
 
     test('with simple query protocol', () async {
-      final endpoint = await server.endpoint;
+      final endpoint = await server.endpoint();
       // Get the PID for conn1
       final res = await conn2.execute(
           "SELECT pid FROM pg_stat_activity where usename = '${endpoint.username}';");

--- a/test/v3_logical_replication_test.dart
+++ b/test/v3_logical_replication_test.dart
@@ -80,7 +80,7 @@ void main() {
       // used to create changes in the db that are reflected in the replication
       // stream
       changesConn = await PgConnection.open(
-        await server.endpoint,
+        await server.endpoint(),
         sessionSettings: PgSessionSettings(
           onBadSslCertificate: (cert) => true,
         ),

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -181,7 +181,7 @@ void main() {
       test('for duplicate with extended query', () async {
         await expectLater(
           () => connection.execute(
-            r'INSERT INTO foo VALUES ($1);',
+            PgSql(r'INSERT INTO foo VALUES ($1);'),
             parameters: [PgTypedParameter(PgDataType.integer, 1)],
           ),
           _throwsPostgresException,
@@ -232,7 +232,7 @@ void main() {
 
         final outValue = await connection.runTx((ctx) async {
           return await ctx.execute(
-            r'SELECT * FROM t WHERE id = $1 LIMIT 1',
+            PgSql(r'SELECT * FROM t WHERE id = $1 LIMIT 1'),
             parameters: [PgTypedParameter(PgDataType.integer, 1)],
           );
         });
@@ -378,7 +378,7 @@ void main() {
       test('parameterized query throws', () async {
         await expectLater(
           () => connection.execute(
-            'SELECT 1',
+            PgSql('SELECT 1'),
             parameters: [PgTypedParameter(PgDataType.integer, 1)],
             queryMode: QueryMode.simple,
           ),


### PR DESCRIPTION
Following the suggestions from https://github.com/isoos/postgresql-dart/issues/105#issuecomment-1676364521, this migrates `test/transaction_test.dart` to use the v3 API.

To make the migration easier, and to keep more compatibility with the v2 API, I've changed the v3 implementation to substitute named variables by default. The few users who'll need full control over SQL in the v3 API can use the `PgSql` wrapper.