### PR TITLE
Fix or skip `query_reuse_test.dart`

### DIFF
--- a/lib/src/client_messages.dart
+++ b/lib/src/client_messages.dart
@@ -160,7 +160,7 @@ class ParseMessage extends ClientMessage {
 
   @override
   String toString() {
-    return 'Parse $_statement';
+    return 'Parse $_statement with types: $_types';
   }
 }
 
@@ -259,6 +259,11 @@ class BindMessage extends ClientMessage {
     // Result columns - we always want binary for all of them, so specify 1:1.
     buffer.writeUint16(1);
     buffer.writeUint16(1);
+  }
+
+  @override
+  String toString() {
+    return 'Bind ($_parameters)';
   }
 }
 

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -248,6 +248,11 @@ class ParameterValue {
     }
     return null;
   }
+
+  @override
+  String toString() {
+    return '($_type, $_value)';
+  }
 }
 
 class FieldDescription implements ColumnDescription {

--- a/test/query_reuse_test.dart
+++ b/test/query_reuse_test.dart
@@ -123,7 +123,9 @@ void main() {
       expect(results, [expectedRow1, expectedRow2]);
 
       expect(hasCachedQueryNamed(connection, insertQueryString), true);
-    });
+    },
+        skip: skippedOnV3(
+            'Tests internals (query cache) which has been removed from v3'));
 
     test('Call query multiple times without type data succeeds ', () async {
       final insertQueryString =
@@ -335,11 +337,13 @@ void main() {
         [3, 4]
       ]);
 
-      expect(
-          hasCachedQueryNamed(
-              connection, 'select i1, i2 from t where i1 > @i1'),
-          true);
-      expect(getQueryCache(connection).length, 1);
+      if (!useV3) {
+        expect(
+            hasCachedQueryNamed(
+                connection, 'select i1, i2 from t where i1 > @i1'),
+            true);
+        expect(getQueryCache(connection).length, 1);
+      }
     });
 
     test('Call query multiple times, mixing in other named queries, succeeds',
@@ -382,7 +386,9 @@ void main() {
           hasCachedQueryNamed(connection, 'select i1,i2 from t where i2 < @i2'),
           true);
       expect(getQueryCache(connection).length, 2);
-    });
+    },
+        skip: skippedOnV3(
+            'Tests internals (query cache) which has been removed from v3'));
 
     test(
         'Call a bunch of named and unnamed queries without awaiting, still process correctly',
@@ -565,7 +571,9 @@ void main() {
       expect(getQueryCache(connection).length, 2); // 1: SELECT 1
       expect(hasCachedQueryNamed(connection, string), true);
     });
-  });
+  },
+      skip: skippedOnV3(
+          'Tests internals (query cache) which has been removed from v3'));
 }
 
 QueryCache getQueryCache(PostgreSQLConnection connection) {

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -68,6 +68,15 @@ void main() {
       expect(res.affectedRows, 2);
     });
 
+    test('fall back to text encoding for untyped parse messages', () async {
+      final stmt = await connection.prepare(PgSql(r'SELECT $1'));
+      final result =
+          await stmt.run([PgTypedParameter(PgDataType.bigInteger, 123)]);
+      expect(result, [
+        ['123']
+      ]);
+    });
+
     group('binary encoding and decoding', () {
       Future<void> shouldPassthrough<T extends Object>(
           PgDataType<T> type, T? value,


### PR DESCRIPTION
This fixes a bug in the v3 implementation causing "insufficient data left in message" problems: Postgres expects textual encodings when no type is given in the `Parse` message, but after #154 we'd auto-detect the type and send a typed (binary) encoding over.

This PR fixes that to always use a textual encoding when the type used in the `Bind` message would otherwise be different from the type in the `Parse` message.