### PR TITLE
Handle unspecified types in queries.

### DIFF
--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -57,8 +57,9 @@ class PostgresBinaryEncoder<T extends Object> {
     // ignore: unnecessary_cast
     switch (_dataType as PgDataType<Object>) {
       case PgDataType.unknownType:
+      case PgDataType.unspecified:
       case PgDataType.voidType:
-        throw ArgumentError('Cannot encode into an unknown type or into void');
+        throw ArgumentError('Cannot encode into ${_dataType.name}.');
       case PgDataType.boolean:
         {
           if (input is bool) {
@@ -621,6 +622,7 @@ class PostgresBinaryDecoder<T> {
         }) as T;
 
       case PostgreSQLDataType.unknownType:
+      case PostgreSQLDataType.unspecified:
         {
           // We'll try and decode this as a utf8 string and return that
           // for many internal types, this is valid. If it fails,

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -234,10 +234,10 @@ class ParameterValue {
     return ParameterValue(type, value);
   }
 
-  bool get hasKnownType => _type != null;
+  late final hasKnownType = _type != null && _type != PgDataType.unspecified;
 
   Uint8List? encodeAsBytes(Encoding encoding) {
-    if (_type != null) {
+    if (hasKnownType) {
       final encoder = PostgresBinaryEncoder(_type!);
       return encoder.convert(_value, encoding);
     }

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -522,13 +522,9 @@ class _PgResultStreamSubscription
 
       connection._channel.sink.add(AggregatedClientMessage([
         BindMessage(
-          statement.parameters.map((p) {
-            PgDataType? type = p.type;
-            if (type == PgDataType.unspecified) {
-              type = null;
-            }
-            return ParameterValue(type, p.value);
-          }).toList(),
+          statement.parameters
+              .map((p) => ParameterValue(p.type, p.value))
+              .toList(),
           portalName: _portalName,
           statementName: statement.statement._name,
         ),

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -522,10 +522,13 @@ class _PgResultStreamSubscription
 
       connection._channel.sink.add(AggregatedClientMessage([
         BindMessage(
-          [
-            for (final parameter in statement.parameters)
-              ParameterValue(parameter.type, parameter.value)
-          ],
+          statement.parameters.map((p) {
+            PgDataType? type = p.type;
+            if (type == PgDataType.unspecified) {
+              type = null;
+            }
+            return ParameterValue(type, p.value);
+          }).toList(),
           portalName: _portalName,
           statementName: statement.statement._name,
         ),

--- a/lib/src/v3/query_description.dart
+++ b/lib/src/v3/query_description.dart
@@ -71,33 +71,8 @@ class InternalQueryDescription implements PgSql {
       return value;
     } else if (knownType != null) {
       return PgTypedParameter(knownType, value);
-    } else if (value == null) {
-      return PgTypedParameter(PgDataType.voidType, value);
-    } else if (value is String) {
-      return PgTypedParameter(PgDataType.varChar, value);
-    } else if (value is bool) {
-      return PgTypedParameter(PgDataType.boolean, value);
-    } else if (value is int && value.bitLength <= 16) {
-      return PgTypedParameter(PgDataType.smallInteger, value);
-    } else if (value is int && value.bitLength <= 32) {
-      return PgTypedParameter(PgDataType.integer, value);
-    } else if (value is int && value.bitLength <= 64) {
-      return PgTypedParameter(PgDataType.bigInteger, value);
-    } else if (value is double) {
-      return PgTypedParameter(PgDataType.double, value);
-    } else if (value is DateTime) {
-      return PgTypedParameter(PgDataType.timestampWithoutTimezone, value);
-    } else if (value is Map<String, dynamic>) {
-      return PgTypedParameter(PgDataType.jsonb, value);
-    } else if (value is PgPoint) {
-      return PgTypedParameter(PgDataType.point, value);
     } else {
-      throw ArgumentError.value(
-        value,
-        name == null ? 'parameter' : '$name parameter',
-        'Is not a `PgTypedParameter` and appears in a location for which no '
-        'type could be inferred.',
-      );
+      return PgTypedParameter(PgDataType.unspecified, value);
     }
   }
 

--- a/lib/src/v3/types.dart
+++ b/lib/src/v3/types.dart
@@ -27,6 +27,9 @@ enum PgDataType<Dart extends Object> {
   /// Used to represent a type not yet understood by this package.
   unknownType<Object>(null),
 
+  /// Used to represent value without any type representation.
+  unspecified<Object>(null),
+
   /// Must be a [String].
   text<String>(25, nameForSubstitution: 'text'),
 

--- a/test/interpolation_test.dart
+++ b/test/interpolation_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 void main() {
   test('Ensure all types/format type mappings are available and accurate', () {
     const withoutMapping = {
+      PostgreSQLDataType.unspecified, // Can't bind into unspecified type
       PostgreSQLDataType.unknownType, // Can't bind into unknown type
       PostgreSQLDataType.voidType, // Can't assign to void
       PostgreSQLDataType.bigSerial, // Can only be created from a table sequence

--- a/test/variable_tokenizer_test.dart
+++ b/test/variable_tokenizer_test.dart
@@ -31,7 +31,7 @@ void main() {
     expect(desc.bindParameters({'x': 4, 'y': true, 'z': 'z'}), [
       PgTypedParameter(PgDataType.bigInteger, 4),
       PgTypedParameter(PgDataType.boolean, true),
-      PgTypedParameter(PgDataType.varChar, 'z'),
+      PgTypedParameter(PgDataType.unspecified, 'z'),
     ]);
 
     // Make sure we can still bind by index
@@ -48,7 +48,7 @@ void main() {
       [
         PgTypedParameter(PgDataType.bigInteger, 1),
         PgTypedParameter(PgDataType.boolean, true),
-        PgTypedParameter(PgDataType.smallInteger, 3),
+        PgTypedParameter(PgDataType.unspecified, 3),
       ],
     );
   });


### PR DESCRIPTION
- Unblocks more queries in `query_tests.dart`.
- Using the insight from @simolus3, and using the encoding of `ParameterValue`.