### PR TITLE
Move skippedOnV3 to the server instance.

### DIFF
--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -153,7 +153,7 @@ void main() {
       final underlyingSocket =
           reflect(conn).getField(socketMirror.simpleName).reflectee;
       expect(underlyingSocket is SecureSocket, true);
-    }, skip: skippedOnV3('Tests internals'));
+    }, skip: server.skippedOnV3('Tests internals'));
 
     test('Connect with no auth required', () async {
       conn = PostgreSQLConnection('localhost', await server.port, 'dart_test',
@@ -507,7 +507,7 @@ void main() {
       final queue =
           reflect(conn).getField(queueMirror.simpleName).reflectee as List;
       expect(queue, isEmpty);
-    }, skip: skippedOnV3('Tests internals'));
+    }, skip: server.skippedOnV3('Tests internals'));
 
     test(
         'A query error maintains connectivity, continues processing pending transactions',
@@ -572,7 +572,7 @@ void main() {
       final queue =
           reflect(conn).getField(queueMirror.simpleName).reflectee as List;
       expect(queue, isEmpty);
-    }, skip: skippedOnV3('Tests internals'));
+    }, skip: server.skippedOnV3('Tests internals'));
   });
 
   group('Network error situations', () {
@@ -783,7 +783,7 @@ void main() {
       await Future.wait(futures);
       expect(conn.queueSize, 0);
     },
-        skip: skippedOnV3(
+        skip: server.skippedOnV3(
             'queueSize is an internal property not exposed in the V3 API'));
   });
 }

--- a/test/docker.dart
+++ b/test/docker.dart
@@ -16,18 +16,6 @@ import 'package:test/test.dart';
 
 bool get _useV3 => Platform.environment['V3'] == '1';
 
-/// Can be used as the `skip` parameter on tests that can't run with the v3
-/// backend for v2 API, for instance because they're testing internals.
-String? skippedOnV3([String? reason]) {
-  if (_useV3) {
-    return reason != null
-        ? 'Skipped with v3 delegate: $reason'
-        : 'Skipped with v3 delegate.';
-  } else {
-    return null;
-  }
-}
-
 // We log all packets sent to and received from the postgres server. This can be
 // used to debug failing tests. To view logs, something like this can be put
 // at the beginning of `main()`:
@@ -60,6 +48,20 @@ class PostgresServer {
   final _containerName = Completer<String>();
 
   Future<int> get port => _port.future;
+
+  bool get useV3 => _useV3;
+
+  /// Can be used as the `skip` parameter on tests that can't run with the v3
+  /// backend for v2 API, for instance because they're testing internals.
+  String? skippedOnV3([String? reason]) {
+    if (_useV3) {
+      return reason != null
+          ? 'Skipped with v3 delegate: $reason'
+          : 'Skipped with v3 delegate.';
+    } else {
+      return null;
+    }
+  }
 
   Future<PgEndpoint> endpoint({
     bool requireSsl = false,

--- a/test/map_return_test.dart
+++ b/test/map_return_test.dart
@@ -120,7 +120,7 @@ void main() {
 
       await connection.mappedResultsQuery('SELECT u.id FROM u');
       expect(getOidQueryCount(connection), 2);
-    }, skip: skippedOnV3('oid cache is not implemented in v3'));
+    }, skip: server.skippedOnV3('oid cache is not implemented in v3'));
 
     test('Non-table mappedResultsQuery succeeds', () async {
       final result = await connection.mappedResultsQuery('SELECT 1');

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -1,5 +1,4 @@
 import 'package:postgres/postgres.dart';
-import 'package:postgres/src/v2_v3_delegate.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';
@@ -46,7 +45,7 @@ void main() {
       expect(
           result.columnDescriptions.single.tableName,
           // v3 does not query the table oids
-          connection is V3BackedPostgreSQLConnection ? '' : 't');
+          server.useV3 ? '' : 't');
       expect(result.columnDescriptions.single.columnName, 't');
       expect(result, [expectedRow]);
     });
@@ -200,9 +199,15 @@ void main() {
         [false, true, false]
       ];
       expect(result.columnDescriptions, hasLength(24));
-      expect(result.columnDescriptions.first.tableName, 't');
+      expect(
+          result.columnDescriptions.first.tableName,
+          // v3 does not query the table oids
+          server.useV3 ? '' : 't');
       expect(result.columnDescriptions.first.columnName, 'i');
-      expect(result.columnDescriptions.last.tableName, 't');
+      expect(
+          result.columnDescriptions.last.tableName,
+          // v3 does not query the table oids
+          server.useV3 ? '' : 't');
       expect(result.columnDescriptions.last.columnName, 'ba');
       expect(result, [expectedRow]);
       result = await connection.query(
@@ -474,7 +479,7 @@ void main() {
       } on FormatException catch (e) {
         expect(
             e.toString(),
-            connection is V3BackedPostgreSQLConnection
+            server.useV3
                 ? contains('Unknown type')
                 : contains('Invalid type code'));
         expect(e.toString(), contains('qwerty'));


### PR DESCRIPTION
- cleared `query_test.dart`, now it is v3-compatible
- moved skippedOnV3 method to `server`, so that we could (in a follow-up PR) run the same tests twice with v2 and v3 mode