### PR TITLE
Implement cancelTransaction + skips for v2_transaction_test.dart

### DIFF
--- a/lib/src/transaction_proxy.dart
+++ b/lib/src/transaction_proxy.dart
@@ -105,7 +105,7 @@ class _TransactionProxy extends Object
     }
 
     if (object is _TransactionRollbackException) {
-      _completer.complete(PostgreSQLRollback._(object.reason));
+      _completer.complete(PostgreSQLRollback(object.reason));
     } else {
       _completer.completeError(object as Object, trace);
     }
@@ -133,7 +133,8 @@ class _TransactionProxy extends Object
 /// returned from [PostgreSQLConnection.transaction] will be an instance of this type. [reason] will be the [String]
 /// value of the optional argument to [PostgreSQLExecutionContext.cancelTransaction].
 class PostgreSQLRollback {
-  PostgreSQLRollback._(this.reason);
+  @internal
+  PostgreSQLRollback(this.reason);
 
   /// The reason the transaction was cancelled.
   final String reason;

--- a/test/v2_transaction_test.dart
+++ b/test/v2_transaction_test.dart
@@ -202,7 +202,7 @@ void main() {
         [2],
         [3]
       ]);
-    });
+    }, skip: server.skippedOnV3('v3 does not support unawaited query queue'));
 
     test(
         "A transaction doesn't have to await on queries, when the last query fails, it still emits an error from the transaction",
@@ -219,7 +219,7 @@ void main() {
 
       final total = await conn.query('SELECT id FROM t');
       expect(total, []);
-    });
+    }, skip: server.skippedOnV3('v3 does not support unawaited query queue'));
 
     test(
         "A transaction doesn't have to await on queries, when the non-last query fails, it still emits an error from the transaction",
@@ -245,7 +245,7 @@ void main() {
           pendingQueryError.toString(), contains('failed prior to execution'));
       final total = await conn.query('SELECT id FROM t');
       expect(total, []);
-    });
+    }, skip: server.skippedOnV3('v3 does not support unawaited query queue'));
 
     test(
         'A transaction with a rollback and non-await queries rolls back transaction',
@@ -269,7 +269,7 @@ void main() {
       expect(total, []);
 
       expect(errs.length, 2);
-    });
+    }, skip: server.skippedOnV3('v3 does not support unawaited query queue'));
 
     test(
         'A transaction that mixes awaiting and non-awaiting queries fails gracefully when an awaited query fails',
@@ -287,7 +287,7 @@ void main() {
       expect(transactionError, isNotNull);
       final total = await conn.query('SELECT id FROM t');
       expect(total, []);
-    });
+    }, skip: server.skippedOnV3('v3 does not support unawaited query queue'));
 
     test(
         'A transaction that mixes awaiting and non-awaiting queries fails gracefully when an unawaited query fails',
@@ -303,7 +303,7 @@ void main() {
       expect(transactionError, isNotNull);
       final total = await conn.query('SELECT id FROM t');
       expect(total, []);
-    });
+    }, skip: server.skippedOnV3('v3 does not support unawaited query queue'));
   });
 
   // A transaction can fail for three reasons: query error, exception in code, or a rollback.
@@ -511,7 +511,7 @@ void main() {
 
       final noRows = await conn.query('SELECT id FROM t');
       expect(noRows, []);
-    });
+    }, skip: server.skippedOnV3('v3 does not support unawaited query queue'));
 
     test('Async query failure prevents closure from continuing', () async {
       var reached = false;


### PR DESCRIPTION
We could add `cancelTransaction` to a new `PgTxSession extends PgSession` interface, but that may happen at a later time. I've started with that implementation, but then `runTx` may not return `<R>` only either untyped object, or a wrapper or `<R?>`...