### PR TITLE
Implement query timeout + enable both v2 and v3 adapter tests

### DIFF
--- a/example/v3/example.dart
+++ b/example/v3/example.dart
@@ -7,7 +7,7 @@ void main() async {
 
   final statement = await connection.prepare(PgSql("SELECT 'foo';"));
   print('has statement');
-  final result = await statement.run();
+  final result = await statement.run([]);
   print(result);
   await statement.dispose();
 

--- a/lib/postgres_v3_experimental.dart
+++ b/lib/postgres_v3_experimental.dart
@@ -144,6 +144,7 @@ abstract class PgSession {
         parameters,
     bool ignoreRows = false,
     QueryMode? queryMode,
+    Duration? timeout,
   });
 
   /// Closes this session, cleaning up resources and forbiding further calls to
@@ -198,13 +199,14 @@ abstract class PgStatement {
       Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */
           parameters);
 
-  Future<PgResult> run([
+  Future<PgResult> run(
     Object? /* List<Object?|PgTypedParameter> | Map<String, Object?|PgTypedParameter> */
-        parameters,
-  ]) async {
+        parameters, {
+    Duration? timeout,
+  }) async {
     final items = <PgResultRow>[];
     final subscription = bind(parameters).listen(items.add);
-    await subscription.asFuture();
+    await subscription.asFuture().optionalTimeout(timeout);
     await subscription.cancel();
 
     return PgResult(

--- a/lib/src/v2_v3_delegate.dart
+++ b/lib/src/v2_v3_delegate.dart
@@ -103,6 +103,9 @@ mixin _DelegatingContext implements PostgreSQLExecutionContext {
         PgSql.map(fmtString),
         parameters: substitutionValues,
         queryMode: (useSimpleQueryProtocol ?? false) ? QueryMode.simple : null,
+        timeout: timeoutInSeconds == null
+            ? null
+            : Duration(seconds: timeoutInSeconds),
       );
       return _PostgreSQLResult(rs, rs.map((e) => _PostgreSQLResultRow(e, e)));
     } else {

--- a/lib/src/v3/pool.dart
+++ b/lib/src/v3/pool.dart
@@ -47,12 +47,14 @@ class PoolImplementation implements PgPool {
     Object? parameters,
     bool ignoreRows = false,
     QueryMode? queryMode,
+    Duration? timeout,
   }) {
     return withConnection((connection) => connection.execute(
           query,
           parameters: parameters,
           ignoreRows: ignoreRows,
           queryMode: queryMode,
+          timeout: timeout,
         ));
   }
 
@@ -171,12 +173,14 @@ class _PoolConnection implements PgConnection {
     Object? parameters,
     bool ignoreRows = false,
     QueryMode? queryMode,
+    Duration? timeout,
   }) {
     return _connection.execute(
       query,
       parameters: parameters,
       ignoreRows: ignoreRows,
       queryMode: queryMode,
+      timeout: timeout,
     );
   }
 
@@ -212,7 +216,10 @@ class _PoolStatement implements PgStatement {
   }
 
   @override
-  Future<PgResult> run([Object? parameters]) {
-    return _underlying.run(parameters);
+  Future<PgResult> run(
+    Object? parameters, {
+    Duration? timeout,
+  }) {
+    return _underlying.run(parameters, timeout: timeout);
   }
 }


### PR DESCRIPTION
Note: `PgStatement.run` has a breaking change in method signature. to be reviewed with the rest of v3 soon.