### PR TITLE
Cleanup of PostgreSQLDataType (using PgDataType instead).

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -1,8 +1,12 @@
 library postgres;
 
+import 'package:postgres/src/v3/types.dart';
+
 export 'src/connection.dart';
 export 'src/execution_context.dart';
 export 'src/replication.dart' show ReplicationMode;
 export 'src/substituter.dart';
 export 'src/types.dart';
 export 'src/v3/types.dart' show PgPoint;
+
+typedef PostgreSQLDataType = PgDataType<Object>;

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -5,7 +5,6 @@ import 'package:buffer/buffer.dart';
 import 'package:postgres/src/v3/types.dart';
 
 import 'buffer.dart';
-import 'types.dart';
 
 final _bool0 = Uint8List(1)..[0] = 0;
 final _bool1 = Uint8List(1)..[0] = 1;
@@ -515,42 +514,42 @@ class PostgresBinaryDecoder<T> {
         ByteData.view(input.buffer, input.offsetInBytes, input.lengthInBytes);
 
     switch (type) {
-      case PostgreSQLDataType.name:
-      case PostgreSQLDataType.text:
-      case PostgreSQLDataType.varChar:
+      case PgDataType.name:
+      case PgDataType.text:
+      case PgDataType.varChar:
         return encoding.decode(input) as T;
-      case PostgreSQLDataType.boolean:
+      case PgDataType.boolean:
         return (buffer.getInt8(0) != 0) as T;
-      case PostgreSQLDataType.smallInteger:
+      case PgDataType.smallInteger:
         return buffer.getInt16(0) as T;
-      case PostgreSQLDataType.serial:
-      case PostgreSQLDataType.integer:
+      case PgDataType.serial:
+      case PgDataType.integer:
         return buffer.getInt32(0) as T;
-      case PostgreSQLDataType.bigSerial:
-      case PostgreSQLDataType.bigInteger:
+      case PgDataType.bigSerial:
+      case PgDataType.bigInteger:
         return buffer.getInt64(0) as T;
-      case PostgreSQLDataType.real:
+      case PgDataType.real:
         return buffer.getFloat32(0) as T;
-      case PostgreSQLDataType.double:
+      case PgDataType.double:
         return buffer.getFloat64(0) as T;
-      case PostgreSQLDataType.timestampWithoutTimezone:
-      case PostgreSQLDataType.timestampWithTimezone:
+      case PgDataType.timestampWithoutTimezone:
+      case PgDataType.timestampWithTimezone:
         return DateTime.utc(2000)
             .add(Duration(microseconds: buffer.getInt64(0))) as T;
 
-      case PostgreSQLDataType.interval:
+      case PgDataType.interval:
         {
           if (buffer.getInt64(8) != 0) throw UnimplementedError();
           return Duration(microseconds: buffer.getInt64(0)) as T;
         }
 
-      case PostgreSQLDataType.numeric:
+      case PgDataType.numeric:
         return _decodeNumeric(input) as T;
 
-      case PostgreSQLDataType.date:
+      case PgDataType.date:
         return DateTime.utc(2000).add(Duration(days: buffer.getInt32(0))) as T;
 
-      case PostgreSQLDataType.jsonb:
+      case PgDataType.jsonb:
         {
           // Removes version which is first character and currently always '1'
           final bytes = input.buffer
@@ -558,13 +557,13 @@ class PostgresBinaryDecoder<T> {
           return _jsonFusedEncoding(encoding).decode(bytes) as T;
         }
 
-      case PostgreSQLDataType.json:
+      case PgDataType.json:
         return _jsonFusedEncoding(encoding).decode(input) as T;
 
-      case PostgreSQLDataType.byteArray:
+      case PgDataType.byteArray:
         return input as T;
 
-      case PostgreSQLDataType.uuid:
+      case PgDataType.uuid:
         {
           final buf = StringBuffer();
           for (var i = 0; i < buffer.lengthInBytes; i++) {
@@ -590,39 +589,39 @@ class PostgresBinaryDecoder<T> {
       case PgDataType.voidType:
         return null;
 
-      case PostgreSQLDataType.point:
+      case PgDataType.point:
         return PgPoint(buffer.getFloat64(0), buffer.getFloat64(8)) as T;
 
-      case PostgreSQLDataType.booleanArray:
+      case PgDataType.booleanArray:
         return readListBytes<bool>(
             input, (reader, _) => reader.readUint8() != 0) as T;
 
-      case PostgreSQLDataType.integerArray:
+      case PgDataType.integerArray:
         return readListBytes<int>(input, (reader, _) => reader.readInt32())
             as T;
-      case PostgreSQLDataType.bigIntegerArray:
+      case PgDataType.bigIntegerArray:
         return readListBytes<int>(input, (reader, _) => reader.readInt64())
             as T;
 
-      case PostgreSQLDataType.varCharArray:
-      case PostgreSQLDataType.textArray:
+      case PgDataType.varCharArray:
+      case PgDataType.textArray:
         return readListBytes<String>(input, (reader, length) {
           return encoding.decode(length > 0 ? reader.read(length) : []);
         }) as T;
 
-      case PostgreSQLDataType.doubleArray:
+      case PgDataType.doubleArray:
         return readListBytes<double>(input, (reader, _) => reader.readFloat64())
             as T;
 
-      case PostgreSQLDataType.jsonbArray:
+      case PgDataType.jsonbArray:
         return readListBytes<dynamic>(input, (reader, length) {
           reader.read(1);
           final bytes = reader.read(length - 1);
           return _jsonFusedEncoding(encoding).decode(bytes);
         }) as T;
 
-      case PostgreSQLDataType.unknownType:
-      case PostgreSQLDataType.unspecified:
+      case PgDataType.unknownType:
+      case PgDataType.unspecified:
         {
           // We'll try and decode this as a utf8 string and return that
           // for many internal types, this is valid. If it fails,
@@ -660,7 +659,7 @@ class PostgresBinaryDecoder<T> {
   }
 
   /// See: https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat
-  static final Map<int, PostgreSQLDataType> typeMap = PgDataType.byTypeOid;
+  static final Map<int, PgDataType> typeMap = PgDataType.byTypeOid;
 
   /// Decode numeric / decimal to String without loosing precision.
   /// See encoding: https://github.com/postgres/postgres/blob/0e39a608ed5545cc6b9d538ac937c3c1ee8cdc36/src/backend/utils/adt/numeric.c#L305

--- a/lib/src/execution_context.dart
+++ b/lib/src/execution_context.dart
@@ -3,7 +3,8 @@ import 'dart:async';
 import 'connection.dart';
 import 'query.dart';
 import 'substituter.dart';
-import 'types.dart';
+
+import 'v3/types.dart';
 
 abstract class PostgreSQLExecutionContext {
   /// Returns this context queue size
@@ -22,7 +23,7 @@ abstract class PostgreSQLExecutionContext {
   ///         connection.query("SELECT * FROM table WHERE id = @idParam:int4", {"idParam" : 2});
   ///
   /// Available types are listed in [PostgreSQLFormatIdentifier.typeStringToCodeMap]. Some types have multiple options. It is preferable to use the [PostgreSQLFormat.id]
-  /// function to add parameters to a query string. This method inserts a parameter name and the appropriate ':type' string for a [PostgreSQLDataType].
+  /// function to add parameters to a query string. This method inserts a parameter name and the appropriate ':type' string for a [PgDataType].
   ///
   /// If successful, the returned [Future] completes with a [List] of rows. Each is row is represented by a [List] of column values for that row that were returned by the query.
   ///

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -12,7 +12,6 @@ import 'connection.dart';
 import 'execution_context.dart';
 import 'substituter.dart';
 import 'text_codec.dart';
-import 'types.dart';
 
 class Query<T> {
   Query(
@@ -38,7 +37,7 @@ class Query<T> {
   final PostgreSQLExecutionContext transaction;
   final PostgreSQLConnection connection;
 
-  late List<PostgreSQLDataType?> _specifiedParameterTypeCodes;
+  late List<PgDataType?> _specifiedParameterTypeCodes;
   final rows = <List<dynamic>>[];
 
   CachedQuery? cache;
@@ -298,8 +297,7 @@ class FieldDescription implements ColumnDescription {
     final formatCode = reader.readUint16();
 
     final converter = PostgresBinaryDecoder(
-        PostgreSQLDataType.byTypeOid[typeOid] ??
-            PostgreSQLDataType.unknownType);
+        PgDataType.byTypeOid[typeOid] ?? PgDataType.unknownType);
     return FieldDescription._(
       converter, fieldName, tableID, columnID, typeOid,
       dataTypeSize, typeModifier, formatCode,
@@ -331,12 +329,12 @@ class PostgreSQLFormatToken {
 }
 
 class PostgreSQLFormatIdentifier {
-  static Map<String, PostgreSQLDataType> typeStringToCodeMap =
-      PostgreSQLDataType.bySubstitutionName;
+  static Map<String, PgDataType> typeStringToCodeMap =
+      PgDataType.bySubstitutionName;
 
   factory PostgreSQLFormatIdentifier(String t) {
     String name;
-    PostgreSQLDataType? type;
+    PgDataType? type;
     String? typeCast;
 
     final components = t.split('::');
@@ -369,6 +367,6 @@ class PostgreSQLFormatIdentifier {
   PostgreSQLFormatIdentifier._(this.name, this.type, this.typeCast);
 
   final String name;
-  final PostgreSQLDataType? type;
+  final PgDataType? type;
   final String? typeCast;
 }

--- a/lib/src/substituter.dart
+++ b/lib/src/substituter.dart
@@ -1,11 +1,12 @@
+import 'package:postgres/src/v3/types.dart';
+
 import 'query.dart';
 import 'text_codec.dart';
-import 'types.dart';
 
 class PostgreSQLFormat {
   static final int _atSignCodeUnit = '@'.codeUnitAt(0);
 
-  static String id(String name, {PostgreSQLDataType? type}) {
+  static String id(String name, {PgDataType? type}) {
     if (type != null) {
       return '@$name:${dataTypeStringForDataType(type)}';
     }
@@ -13,7 +14,7 @@ class PostgreSQLFormat {
     return '@$name';
   }
 
-  static String? dataTypeStringForDataType(PostgreSQLDataType? dt) {
+  static String? dataTypeStringForDataType(PgDataType? dt) {
     return dt?.nameForSubstitution;
   }
 

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -9,10 +9,6 @@
   5. add identifying key to PostgreSQLFormat.dataTypeStringForDataType
  */
 
-import 'package:postgres/src/v3/types.dart';
-
-typedef PostgreSQLDataType = PgDataType<Object>;
-
 /// LSN is a PostgreSQL Log Sequence Number.
 ///
 /// For more details, see: https://www.postgresql.org/docs/current/datatype-pg-lsn.html

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:postgres/postgres.dart';
 import 'package:postgres/src/binary_codec.dart';
+import 'package:postgres/src/v3/types.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';
@@ -249,7 +250,7 @@ void main() {
         '0.0': [0, 0, 0, 0, 0, 0, 0, 1], // .0 or 0.0
       };
 
-      final decoder = PostgresBinaryDecoder(PostgreSQLDataType.numeric);
+      final decoder = PostgresBinaryDecoder(PgDataType.numeric);
       binaries.forEach((key, value) {
         final uint8List = Uint8List.fromList(value);
         final res = decoder.convert(uint8List, utf8);

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:postgres/postgres.dart';
 import 'package:postgres/src/binary_codec.dart';
 import 'package:postgres/src/text_codec.dart';
+import 'package:postgres/src/v3/types.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';
@@ -27,8 +28,8 @@ void main() {
     // 2. can actually encode and decode a real pg query
     // it also creates a table named t with column v of type being tested
     test('bool', () async {
-      await expectInverse(true, PostgreSQLDataType.boolean);
-      await expectInverse(false, PostgreSQLDataType.boolean);
+      await expectInverse(true, PgDataType.boolean);
+      await expectInverse(false, PgDataType.boolean);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:boolean)',
             substitutionValues: {'v': 'not-bool'});
@@ -39,9 +40,9 @@ void main() {
     });
 
     test('smallint', () async {
-      await expectInverse(-1, PostgreSQLDataType.smallInteger);
-      await expectInverse(0, PostgreSQLDataType.smallInteger);
-      await expectInverse(1, PostgreSQLDataType.smallInteger);
+      await expectInverse(-1, PgDataType.smallInteger);
+      await expectInverse(0, PgDataType.smallInteger);
+      await expectInverse(1, PgDataType.smallInteger);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:int2)',
             substitutionValues: {'v': 'not-int2'});
@@ -52,9 +53,9 @@ void main() {
     });
 
     test('integer', () async {
-      await expectInverse(-1, PostgreSQLDataType.integer);
-      await expectInverse(0, PostgreSQLDataType.integer);
-      await expectInverse(1, PostgreSQLDataType.integer);
+      await expectInverse(-1, PgDataType.integer);
+      await expectInverse(0, PgDataType.integer);
+      await expectInverse(1, PgDataType.integer);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:int4)',
             substitutionValues: {'v': 'not-int4'});
@@ -65,8 +66,8 @@ void main() {
     });
 
     test('serial', () async {
-      await expectInverse(0, PostgreSQLDataType.serial);
-      await expectInverse(1, PostgreSQLDataType.serial);
+      await expectInverse(0, PgDataType.serial);
+      await expectInverse(1, PgDataType.serial);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:int4)',
             substitutionValues: {'v': 'not-serial'});
@@ -77,9 +78,9 @@ void main() {
     });
 
     test('bigint', () async {
-      await expectInverse(-1, PostgreSQLDataType.bigInteger);
-      await expectInverse(0, PostgreSQLDataType.bigInteger);
-      await expectInverse(1, PostgreSQLDataType.bigInteger);
+      await expectInverse(-1, PgDataType.bigInteger);
+      await expectInverse(0, PgDataType.bigInteger);
+      await expectInverse(1, PgDataType.bigInteger);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:int8)',
             substitutionValues: {'v': 'not-int8'});
@@ -90,8 +91,8 @@ void main() {
     });
 
     test('bigserial', () async {
-      await expectInverse(0, PostgreSQLDataType.bigSerial);
-      await expectInverse(1, PostgreSQLDataType.bigSerial);
+      await expectInverse(0, PgDataType.bigSerial);
+      await expectInverse(1, PgDataType.bigSerial);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:int8)',
             substitutionValues: {'v': 'not-bigserial'});
@@ -102,10 +103,10 @@ void main() {
     });
 
     test('text', () async {
-      await expectInverse('', PostgreSQLDataType.text);
-      await expectInverse('foo', PostgreSQLDataType.text);
-      await expectInverse('foo\n', PostgreSQLDataType.text);
-      await expectInverse('foo\nbar;s', PostgreSQLDataType.text);
+      await expectInverse('', PgDataType.text);
+      await expectInverse('foo', PgDataType.text);
+      await expectInverse('foo\n', PgDataType.text);
+      await expectInverse('foo\nbar;s', PgDataType.text);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:text)',
             substitutionValues: {'v': 0});
@@ -116,9 +117,9 @@ void main() {
     });
 
     test('real', () async {
-      await expectInverse(-1.0, PostgreSQLDataType.real);
-      await expectInverse(0.0, PostgreSQLDataType.real);
-      await expectInverse(1.0, PostgreSQLDataType.real);
+      await expectInverse(-1.0, PgDataType.real);
+      await expectInverse(0.0, PgDataType.real);
+      await expectInverse(1.0, PgDataType.real);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:float4)',
             substitutionValues: {'v': 'not-real'});
@@ -129,9 +130,9 @@ void main() {
     });
 
     test('double', () async {
-      await expectInverse(-1.0, PostgreSQLDataType.double);
-      await expectInverse(0.0, PostgreSQLDataType.double);
-      await expectInverse(1.0, PostgreSQLDataType.double);
+      await expectInverse(-1.0, PgDataType.double);
+      await expectInverse(0.0, PgDataType.double);
+      await expectInverse(1.0, PgDataType.double);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:float8)',
             substitutionValues: {'v': 'not-double'});
@@ -142,9 +143,9 @@ void main() {
     });
 
     test('date', () async {
-      await expectInverse(DateTime.utc(1920, 10, 1), PostgreSQLDataType.date);
-      await expectInverse(DateTime.utc(2120, 10, 5), PostgreSQLDataType.date);
-      await expectInverse(DateTime.utc(2016, 10, 1), PostgreSQLDataType.date);
+      await expectInverse(DateTime.utc(1920, 10, 1), PgDataType.date);
+      await expectInverse(DateTime.utc(2120, 10, 5), PgDataType.date);
+      await expectInverse(DateTime.utc(2016, 10, 1), PgDataType.date);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:date)',
             substitutionValues: {'v': 'not-date'});
@@ -155,10 +156,10 @@ void main() {
     });
 
     test('timestamp', () async {
-      await expectInverse(DateTime.utc(1920, 10, 1),
-          PostgreSQLDataType.timestampWithoutTimezone);
-      await expectInverse(DateTime.utc(2120, 10, 5),
-          PostgreSQLDataType.timestampWithoutTimezone);
+      await expectInverse(
+          DateTime.utc(1920, 10, 1), PgDataType.timestampWithoutTimezone);
+      await expectInverse(
+          DateTime.utc(2120, 10, 5), PgDataType.timestampWithoutTimezone);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:timestamp)',
             substitutionValues: {'v': 'not-timestamp'});
@@ -170,9 +171,9 @@ void main() {
 
     test('timestamptz', () async {
       await expectInverse(
-          DateTime.utc(1920, 10, 1), PostgreSQLDataType.timestampWithTimezone);
+          DateTime.utc(1920, 10, 1), PgDataType.timestampWithTimezone);
       await expectInverse(
-          DateTime.utc(2120, 10, 5), PostgreSQLDataType.timestampWithTimezone);
+          DateTime.utc(2120, 10, 5), PgDataType.timestampWithTimezone);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:timestamptz)',
             substitutionValues: {'v': 'not-timestamptz'});
@@ -183,15 +184,13 @@ void main() {
     });
 
     test('interval', () async {
-      await expectInverse(Duration(minutes: 15), PostgreSQLDataType.interval);
+      await expectInverse(Duration(minutes: 15), PgDataType.interval);
+      await expectInverse(Duration(days: 1, minutes: 15), PgDataType.interval);
+      await expectInverse(-Duration(days: 1, seconds: 5), PgDataType.interval);
       await expectInverse(
-          Duration(days: 1, minutes: 15), PostgreSQLDataType.interval);
+          Duration(days: 365 * 100000, microseconds: 1), PgDataType.interval);
       await expectInverse(
-          -Duration(days: 1, seconds: 5), PostgreSQLDataType.interval);
-      await expectInverse(Duration(days: 365 * 100000, microseconds: 1),
-          PostgreSQLDataType.interval);
-      await expectInverse(-Duration(days: 365 * 100000, microseconds: 1),
-          PostgreSQLDataType.interval);
+          -Duration(days: 365 * 100000, microseconds: 1), PgDataType.interval);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:interval)',
             substitutionValues: {'v': 'not-interval'});
@@ -248,7 +247,7 @@ void main() {
         '0.0': [0, 0, 0, 0, 0, 0, 0, 1], // .0 or 0.0
       };
 
-      final encoder = PostgresBinaryEncoder<Object>(PostgreSQLDataType.numeric);
+      final encoder = PostgresBinaryEncoder<Object>(PgDataType.numeric);
       binaries.forEach((key, value) {
         final uint8List = Uint8List.fromList(value);
         final res = encoder.convert(key, utf8);
@@ -257,24 +256,24 @@ void main() {
 
       await expectInverse(
           '1000000000000000000000000000.0000000000000000000000000001',
-          PostgreSQLDataType.numeric);
+          PgDataType.numeric);
       await expectInverse(
           '3141592653589793238462643383279502.1618033988749894848204586834365638',
-          PostgreSQLDataType.numeric);
+          PgDataType.numeric);
       await expectInverse(
           '-3141592653589793238462643383279502.1618033988749894848204586834365638',
-          PostgreSQLDataType.numeric);
-      await expectInverse('0.0', PostgreSQLDataType.numeric);
-      await expectInverse('0.1', PostgreSQLDataType.numeric);
-      await expectInverse('0.0001', PostgreSQLDataType.numeric);
-      await expectInverse('0.00001', PostgreSQLDataType.numeric);
-      await expectInverse('0.000001', PostgreSQLDataType.numeric);
-      await expectInverse('0.000000001', PostgreSQLDataType.numeric);
-      await expectInverse('1.000000000', PostgreSQLDataType.numeric);
-      await expectInverse('1000.000000000', PostgreSQLDataType.numeric);
-      await expectInverse('10000.000000000', PostgreSQLDataType.numeric);
-      await expectInverse('100000000.00000000', PostgreSQLDataType.numeric);
-      await expectInverse('NaN', PostgreSQLDataType.numeric);
+          PgDataType.numeric);
+      await expectInverse('0.0', PgDataType.numeric);
+      await expectInverse('0.1', PgDataType.numeric);
+      await expectInverse('0.0001', PgDataType.numeric);
+      await expectInverse('0.00001', PgDataType.numeric);
+      await expectInverse('0.000001', PgDataType.numeric);
+      await expectInverse('0.000000001', PgDataType.numeric);
+      await expectInverse('1.000000000', PgDataType.numeric);
+      await expectInverse('1000.000000000', PgDataType.numeric);
+      await expectInverse('10000.000000000', PgDataType.numeric);
+      await expectInverse('100000000.00000000', PgDataType.numeric);
+      await expectInverse('NaN', PgDataType.numeric);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:numeric)',
             substitutionValues: {'v': 'not-numeric'});
@@ -285,14 +284,14 @@ void main() {
     });
 
     test('jsonb', () async {
-      await expectInverse('string', PostgreSQLDataType.jsonb);
-      await expectInverse(2, PostgreSQLDataType.jsonb);
-      await expectInverse(['foo'], PostgreSQLDataType.jsonb);
+      await expectInverse('string', PgDataType.jsonb);
+      await expectInverse(2, PgDataType.jsonb);
+      await expectInverse(['foo'], PgDataType.jsonb);
       await expectInverse({
         'key': 'val',
         'key1': 1,
         'array': ['foo']
-      }, PostgreSQLDataType.jsonb);
+      }, PgDataType.jsonb);
 
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:jsonb)',
@@ -302,9 +301,9 @@ void main() {
     });
 
     test('bytea', () async {
-      await expectInverse([0], PostgreSQLDataType.byteArray);
-      await expectInverse([1, 2, 3, 4, 5], PostgreSQLDataType.byteArray);
-      await expectInverse([255, 254, 253], PostgreSQLDataType.byteArray);
+      await expectInverse([0], PgDataType.byteArray);
+      await expectInverse([1, 2, 3, 4, 5], PgDataType.byteArray);
+      await expectInverse([255, 254, 253], PgDataType.byteArray);
 
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:bytea)',
@@ -317,9 +316,9 @@ void main() {
 
     test('uuid', () async {
       await expectInverse(
-          '00000000-0000-0000-0000-000000000000', PostgreSQLDataType.uuid);
+          '00000000-0000-0000-0000-000000000000', PgDataType.uuid);
       await expectInverse(
-          '12345678-abcd-efab-cdef-012345678901', PostgreSQLDataType.uuid);
+          '12345678-abcd-efab-cdef-012345678901', PgDataType.uuid);
 
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:uuid)',
@@ -331,10 +330,10 @@ void main() {
     });
 
     test('varchar', () async {
-      await expectInverse('', PostgreSQLDataType.varChar);
-      await expectInverse('foo', PostgreSQLDataType.varChar);
-      await expectInverse('foo\n', PostgreSQLDataType.varChar);
-      await expectInverse('foo\nbar;s', PostgreSQLDataType.varChar);
+      await expectInverse('', PgDataType.varChar);
+      await expectInverse('foo', PgDataType.varChar);
+      await expectInverse('foo\n', PgDataType.varChar);
+      await expectInverse('foo\nbar;s', PgDataType.varChar);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:varchar)',
             substitutionValues: {'v': 0});
@@ -345,14 +344,14 @@ void main() {
     });
 
     test('json', () async {
-      await expectInverse('string', PostgreSQLDataType.json);
-      await expectInverse(2, PostgreSQLDataType.json);
-      await expectInverse(['foo'], PostgreSQLDataType.json);
+      await expectInverse('string', PgDataType.json);
+      await expectInverse(2, PgDataType.json);
+      await expectInverse(['foo'], PgDataType.json);
       await expectInverse({
         'key': 'val',
         'key1': 1,
         'array': ['foo']
-      }, PostgreSQLDataType.json);
+      }, PgDataType.json);
 
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:json)',
@@ -362,9 +361,9 @@ void main() {
     });
 
     test('point', () async {
-      await expectInverse(PgPoint(0, 0), PostgreSQLDataType.point);
-      await expectInverse(PgPoint(100, 123.456), PostgreSQLDataType.point);
-      await expectInverse(PgPoint(0.001, -999), PostgreSQLDataType.point);
+      await expectInverse(PgPoint(0, 0), PgDataType.point);
+      await expectInverse(PgPoint(100, 123.456), PgDataType.point);
+      await expectInverse(PgPoint(0.001, -999), PgDataType.point);
 
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:point)',
@@ -376,9 +375,9 @@ void main() {
     });
 
     test('booleanArray', () async {
-      await expectInverse(<bool>[], PostgreSQLDataType.booleanArray);
-      await expectInverse([false, true], PostgreSQLDataType.booleanArray);
-      await expectInverse([true], PostgreSQLDataType.booleanArray);
+      await expectInverse(<bool>[], PgDataType.booleanArray);
+      await expectInverse([false, true], PgDataType.booleanArray);
+      await expectInverse([true], PgDataType.booleanArray);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:_bool)',
             substitutionValues: {'v': 'not-list-bool'});
@@ -389,9 +388,9 @@ void main() {
     });
 
     test('integerArray', () async {
-      await expectInverse(<int>[], PostgreSQLDataType.integerArray);
-      await expectInverse([-1, 0, 200], PostgreSQLDataType.integerArray);
-      await expectInverse([-123], PostgreSQLDataType.integerArray);
+      await expectInverse(<int>[], PgDataType.integerArray);
+      await expectInverse([-1, 0, 200], PgDataType.integerArray);
+      await expectInverse([-123], PgDataType.integerArray);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:_int4)',
             substitutionValues: {'v': 'not-list-int'});
@@ -402,9 +401,9 @@ void main() {
     });
 
     test('bigIntegerArray', () async {
-      await expectInverse(<int>[], PostgreSQLDataType.bigIntegerArray);
-      await expectInverse([-1, 0, 200], PostgreSQLDataType.bigIntegerArray);
-      await expectInverse([-123], PostgreSQLDataType.bigIntegerArray);
+      await expectInverse(<int>[], PgDataType.bigIntegerArray);
+      await expectInverse([-1, 0, 200], PgDataType.bigIntegerArray);
+      await expectInverse([-123], PgDataType.bigIntegerArray);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:_int8)',
             substitutionValues: {'v': 'not-list-int'});
@@ -415,9 +414,9 @@ void main() {
     });
 
     test('doubleArray', () async {
-      await expectInverse(<double>[], PostgreSQLDataType.doubleArray);
-      await expectInverse([-123.0, 0.0, 1.0], PostgreSQLDataType.doubleArray);
-      await expectInverse([0.001, 45.678], PostgreSQLDataType.doubleArray);
+      await expectInverse(<double>[], PgDataType.doubleArray);
+      await expectInverse([-123.0, 0.0, 1.0], PgDataType.doubleArray);
+      await expectInverse([0.001, 45.678], PgDataType.doubleArray);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:_float8)',
             substitutionValues: {'v': 'not-list-double'});
@@ -428,11 +427,9 @@ void main() {
     });
 
     test('varCharArray', () async {
-      await expectInverse(<String>[], PostgreSQLDataType.varCharArray);
-      await expectInverse(
-          ['', 'foo', 'foo\n'], PostgreSQLDataType.varCharArray);
-      await expectInverse(
-          ['foo\nbar;s', '"\'"'], PostgreSQLDataType.varCharArray);
+      await expectInverse(<String>[], PgDataType.varCharArray);
+      await expectInverse(['', 'foo', 'foo\n'], PgDataType.varCharArray);
+      await expectInverse(['foo\nbar;s', '"\'"'], PgDataType.varCharArray);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:_varchar(10))',
             substitutionValues: {'v': 0});
@@ -443,9 +440,9 @@ void main() {
     });
 
     test('textArray', () async {
-      await expectInverse(<String>[], PostgreSQLDataType.textArray);
-      await expectInverse(['', 'foo', 'foo\n'], PostgreSQLDataType.textArray);
-      await expectInverse(['foo\nbar;s', '"\'"'], PostgreSQLDataType.textArray);
+      await expectInverse(<String>[], PgDataType.textArray);
+      await expectInverse(['', 'foo', 'foo\n'], PgDataType.textArray);
+      await expectInverse(['foo\nbar;s', '"\'"'], PgDataType.textArray);
       try {
         await conn.query('INSERT INTO t (v) VALUES (@v:_text)',
             substitutionValues: {'v': 0});
@@ -456,12 +453,12 @@ void main() {
     });
 
     test('jsonbArray', () async {
-      await expectInverse(['string', 2, 0.1], PostgreSQLDataType.jsonbArray);
+      await expectInverse(['string', 2, 0.1], PgDataType.jsonbArray);
       await expectInverse([
         1,
         {},
         {'a': 'b'}
-      ], PostgreSQLDataType.jsonbArray);
+      ], PgDataType.jsonbArray);
       await expectInverse([
         ['foo'],
         [
@@ -470,14 +467,14 @@ void main() {
             'a': ['b']
           }
         ]
-      ], PostgreSQLDataType.jsonbArray);
+      ], PgDataType.jsonbArray);
       await expectInverse([
         {
           'key': 'val',
           'key1': 1,
           'array': ['foo']
         }
-      ], PostgreSQLDataType.jsonbArray);
+      ], PgDataType.jsonbArray);
 
       try {
         await conn
@@ -492,7 +489,7 @@ void main() {
       final result = await conn.query('SELECT NULL::void AS r');
       expect(result.columnDescriptions, [
         isA<ColumnDescription>()
-            .having((e) => e.typeId, 'typeId', PostgreSQLDataType.voidType.oid)
+            .having((e) => e.typeId, 'typeId', PgDataType.voidType.oid)
       ]);
 
       expect(result, [
@@ -500,17 +497,14 @@ void main() {
       ]);
 
       expect(
-        () =>
-            PostgresBinaryEncoder(PostgreSQLDataType.voidType).convert(1, utf8),
+        () => PostgresBinaryEncoder(PgDataType.voidType).convert(1, utf8),
         throwsArgumentError,
       );
     });
 
     test('regtype', () async {
-      await expectInverse(
-          PostgreSQLDataType.bigInteger, PostgreSQLDataType.regtype);
-      await expectInverse(
-          PostgreSQLDataType.voidType, PostgreSQLDataType.regtype);
+      await expectInverse(PgDataType.bigInteger, PgDataType.regtype);
+      await expectInverse(PgDataType.voidType, PgDataType.regtype);
     });
   });
 
@@ -630,7 +624,7 @@ void main() {
   });
 
   test('Invalid UUID encoding', () {
-    final converter = PostgresBinaryEncoder<Object>(PostgreSQLDataType.uuid);
+    final converter = PostgresBinaryEncoder<Object>(PgDataType.uuid);
     try {
       converter.convert('z0000000-0000-0000-0000-000000000000', utf8);
       fail('unreachable');
@@ -661,7 +655,7 @@ void main() {
   });
 }
 
-Future expectInverse(dynamic value, PostgreSQLDataType dataType) async {
+Future expectInverse(dynamic value, PgDataType dataType) async {
   final type = PostgreSQLFormat.dataTypeStringForDataType(dataType);
 
   await conn.execute('CREATE TEMPORARY TABLE IF NOT EXISTS t (v $type)');
@@ -673,10 +667,10 @@ Future expectInverse(dynamic value, PostgreSQLDataType dataType) async {
   final encoder = PostgresBinaryEncoder(dataType);
   final encodedValue = encoder.convert(value, utf8);
 
-  if (dataType == PostgreSQLDataType.serial) {
-    dataType = PostgreSQLDataType.integer;
-  } else if (dataType == PostgreSQLDataType.bigSerial) {
-    dataType = PostgreSQLDataType.bigInteger;
+  if (dataType == PgDataType.serial) {
+    dataType = PgDataType.integer;
+  } else if (dataType == PgDataType.bigSerial) {
+    dataType = PgDataType.bigInteger;
   }
 
   final decoder = PostgresBinaryDecoder(dataType);

--- a/test/interpolation_test.dart
+++ b/test/interpolation_test.dart
@@ -2,19 +2,20 @@ import 'dart:convert';
 
 import 'package:postgres/postgres.dart';
 import 'package:postgres/src/query.dart';
+import 'package:postgres/src/v3/types.dart';
 import 'package:test/test.dart';
 
 void main() {
   test('Ensure all types/format type mappings are available and accurate', () {
     const withoutMapping = {
-      PostgreSQLDataType.unspecified, // Can't bind into unspecified type
-      PostgreSQLDataType.unknownType, // Can't bind into unknown type
-      PostgreSQLDataType.voidType, // Can't assign to void
-      PostgreSQLDataType.bigSerial, // Can only be created from a table sequence
-      PostgreSQLDataType.serial,
+      PgDataType.unspecified, // Can't bind into unspecified type
+      PgDataType.unknownType, // Can't bind into unknown type
+      PgDataType.voidType, // Can't assign to void
+      PgDataType.bigSerial, // Can only be created from a table sequence
+      PgDataType.serial,
     };
 
-    for (final type in PostgreSQLDataType.values) {
+    for (final type in PgDataType.values) {
       if (withoutMapping.contains(type)) continue;
 
       expect(
@@ -29,14 +30,11 @@ void main() {
 
   test('Ensure bigserial gets translated to int8', () {
     expect(
-        PostgreSQLFormat.dataTypeStringForDataType(PostgreSQLDataType.serial),
-        'int4');
+        PostgreSQLFormat.dataTypeStringForDataType(PgDataType.serial), 'int4');
   });
 
   test('Ensure serial gets translated to int4', () {
-    expect(
-        PostgreSQLFormat.dataTypeStringForDataType(
-            PostgreSQLDataType.bigSerial),
+    expect(PostgreSQLFormat.dataTypeStringForDataType(PgDataType.bigSerial),
         'int8');
   });
 

--- a/test/query_reuse_test.dart
+++ b/test/query_reuse_test.dart
@@ -3,12 +3,12 @@ import 'dart:mirrors';
 
 import 'package:postgres/postgres.dart';
 import 'package:postgres/src/query_cache.dart';
+import 'package:postgres/src/v3/types.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';
 
-String sid(String id, PostgreSQLDataType dt) =>
-    PostgreSQLFormat.id(id, type: dt);
+String sid(String id, PgDataType dt) => PostgreSQLFormat.id(id, type: dt);
 
 void main() {
   withPostgresServer('Retaining type information', (server) {
@@ -29,11 +29,11 @@ void main() {
         () async {
       final insertQueryString =
           'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz) VALUES '
-          '(${sid('i', PostgreSQLDataType.integer)}, ${sid('bi', PostgreSQLDataType.bigInteger)},'
-          '${sid('bl', PostgreSQLDataType.boolean)}, ${sid('si', PostgreSQLDataType.smallInteger)},'
-          '${sid('t', PostgreSQLDataType.text)}, ${sid('f', PostgreSQLDataType.real)},'
-          '${sid('d', PostgreSQLDataType.double)}, ${sid('dt', PostgreSQLDataType.date)},'
-          '${sid('ts', PostgreSQLDataType.timestampWithoutTimezone)}, ${sid('tsz', PostgreSQLDataType.timestampWithTimezone)}'
+          '(${sid('i', PgDataType.integer)}, ${sid('bi', PgDataType.bigInteger)},'
+          '${sid('bl', PgDataType.boolean)}, ${sid('si', PgDataType.smallInteger)},'
+          '${sid('t', PgDataType.text)}, ${sid('f', PgDataType.real)},'
+          '${sid('d', PgDataType.double)}, ${sid('dt', PgDataType.date)},'
+          '${sid('ts', PgDataType.timestampWithoutTimezone)}, ${sid('tsz', PgDataType.timestampWithTimezone)}'
           ') returning i, s, bi, bs, bl, si, t, f, d, dt, ts, tsz';
       var results =
           await connection.query(insertQueryString, substitutionValues: {
@@ -202,11 +202,11 @@ void main() {
         () async {
       final insertQueryString =
           'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz) VALUES '
-          '(${sid('i', PostgreSQLDataType.integer)}, @bi,'
-          '${sid('bl', PostgreSQLDataType.boolean)}, @si,'
-          '${sid('t', PostgreSQLDataType.text)}, @f,'
-          '${sid('d', PostgreSQLDataType.double)}, @dt,'
-          '${sid('ts', PostgreSQLDataType.timestampWithoutTimezone)}, @tsz'
+          '(${sid('i', PgDataType.integer)}, @bi,'
+          '${sid('bl', PgDataType.boolean)}, @si,'
+          '${sid('t', PgDataType.text)}, @f,'
+          '${sid('d', PgDataType.double)}, @dt,'
+          '${sid('ts', PgDataType.timestampWithoutTimezone)}, @tsz'
           ') returning i, s, bi, bs, bl, si, t, f, d, dt, ts, tsz';
       var results =
           await connection.query(insertQueryString, substitutionValues: {

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -1,4 +1,5 @@
 import 'package:postgres/postgres.dart';
+import 'package:postgres/src/v3/types.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';
@@ -31,7 +32,7 @@ void main() {
     test('UTF16 strings in value', () async {
       var result = await connection.query(
           'INSERT INTO t (t) values '
-          "(${PostgreSQLFormat.id("t", type: PostgreSQLDataType.text)})"
+          "(${PostgreSQLFormat.id("t", type: PgDataType.text)})"
           'returning t',
           substitutionValues: {
             't': '°∆',
@@ -64,7 +65,7 @@ void main() {
     test('UTF16 strings in value with escape characters', () async {
       await connection.execute(
           'INSERT INTO t (t) values '
-          '(${PostgreSQLFormat.id('t', type: PostgreSQLDataType.text)})',
+          '(${PostgreSQLFormat.id('t', type: PgDataType.text)})',
           substitutionValues: {
             't': "'©™®'",
           });
@@ -78,7 +79,7 @@ void main() {
     test('UTF16 strings in value with backslash', () async {
       await connection.execute(
           'INSERT INTO t (t) values '
-          '(${PostgreSQLFormat.id('t', type: PostgreSQLDataType.text)})',
+          '(${PostgreSQLFormat.id('t', type: PgDataType.text)})',
           substitutionValues: {
             't': r"°\'©™®'",
           });
@@ -100,7 +101,7 @@ void main() {
 
     test('Really long raw substitution value', () async {
       final result = await connection.query(
-          "INSERT INTO t (t) VALUES (${PostgreSQLFormat.id("t", type: PostgreSQLDataType.text)}) returning t;",
+          "INSERT INTO t (t) VALUES (${PostgreSQLFormat.id("t", type: PgDataType.text)}) returning t;",
           substitutionValues: {'t': lorumIpsum});
       expect(result, [
         [lorumIpsum]
@@ -218,28 +219,28 @@ void main() {
     test('Query by specifying all types', () async {
       var result = await connection.query(
           'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz, j, u, v, p, jj, ia, bia, ta, da, ja, va, ba) values '
-          '(${PostgreSQLFormat.id('i', type: PostgreSQLDataType.integer)},'
-          '${PostgreSQLFormat.id('bi', type: PostgreSQLDataType.bigInteger)},'
-          '${PostgreSQLFormat.id('bl', type: PostgreSQLDataType.boolean)},'
-          '${PostgreSQLFormat.id('si', type: PostgreSQLDataType.smallInteger)},'
-          '${PostgreSQLFormat.id('t', type: PostgreSQLDataType.text)},'
-          '${PostgreSQLFormat.id('f', type: PostgreSQLDataType.real)},'
-          '${PostgreSQLFormat.id('d', type: PostgreSQLDataType.double)},'
-          '${PostgreSQLFormat.id('dt', type: PostgreSQLDataType.date)},'
-          '${PostgreSQLFormat.id('ts', type: PostgreSQLDataType.timestampWithoutTimezone)},'
-          '${PostgreSQLFormat.id('tsz', type: PostgreSQLDataType.timestampWithTimezone)},'
-          '${PostgreSQLFormat.id('j', type: PostgreSQLDataType.jsonb)},'
-          '${PostgreSQLFormat.id('u', type: PostgreSQLDataType.uuid)},'
-          '${PostgreSQLFormat.id('v', type: PostgreSQLDataType.varChar)},'
-          '${PostgreSQLFormat.id('p', type: PostgreSQLDataType.point)},'
-          '${PostgreSQLFormat.id('jj', type: PostgreSQLDataType.json)},'
-          '${PostgreSQLFormat.id('ia', type: PostgreSQLDataType.integerArray)},'
-          '${PostgreSQLFormat.id('bia', type: PostgreSQLDataType.bigIntegerArray)},'
-          '${PostgreSQLFormat.id('ta', type: PostgreSQLDataType.textArray)},'
-          '${PostgreSQLFormat.id('da', type: PostgreSQLDataType.doubleArray)},'
-          '${PostgreSQLFormat.id('ja', type: PostgreSQLDataType.jsonbArray)},'
-          '${PostgreSQLFormat.id('va', type: PostgreSQLDataType.varCharArray)},'
-          '${PostgreSQLFormat.id('ba', type: PostgreSQLDataType.booleanArray)}'
+          '(${PostgreSQLFormat.id('i', type: PgDataType.integer)},'
+          '${PostgreSQLFormat.id('bi', type: PgDataType.bigInteger)},'
+          '${PostgreSQLFormat.id('bl', type: PgDataType.boolean)},'
+          '${PostgreSQLFormat.id('si', type: PgDataType.smallInteger)},'
+          '${PostgreSQLFormat.id('t', type: PgDataType.text)},'
+          '${PostgreSQLFormat.id('f', type: PgDataType.real)},'
+          '${PostgreSQLFormat.id('d', type: PgDataType.double)},'
+          '${PostgreSQLFormat.id('dt', type: PgDataType.date)},'
+          '${PostgreSQLFormat.id('ts', type: PgDataType.timestampWithoutTimezone)},'
+          '${PostgreSQLFormat.id('tsz', type: PgDataType.timestampWithTimezone)},'
+          '${PostgreSQLFormat.id('j', type: PgDataType.jsonb)},'
+          '${PostgreSQLFormat.id('u', type: PgDataType.uuid)},'
+          '${PostgreSQLFormat.id('v', type: PgDataType.varChar)},'
+          '${PostgreSQLFormat.id('p', type: PgDataType.point)},'
+          '${PostgreSQLFormat.id('jj', type: PgDataType.json)},'
+          '${PostgreSQLFormat.id('ia', type: PgDataType.integerArray)},'
+          '${PostgreSQLFormat.id('bia', type: PgDataType.bigIntegerArray)},'
+          '${PostgreSQLFormat.id('ta', type: PgDataType.textArray)},'
+          '${PostgreSQLFormat.id('da', type: PgDataType.doubleArray)},'
+          '${PostgreSQLFormat.id('ja', type: PgDataType.jsonbArray)},'
+          '${PostgreSQLFormat.id('va', type: PgDataType.varCharArray)},'
+          '${PostgreSQLFormat.id('ba', type: PgDataType.booleanArray)}'
           ') returning i,s, bi, bs, bl, si, t, f, d, dt, ts, tsz, j, u, v, p, jj, ia, bia, ta, da, ja, va, ba',
           substitutionValues: {
             'i': 1,
@@ -311,15 +312,15 @@ void main() {
       var result = await connection.query(
           'INSERT INTO t (i, bi, bl, si, t, f, d, dt, ts, tsz) values '
           '(${PostgreSQLFormat.id('i')},'
-          '${PostgreSQLFormat.id('bi', type: PostgreSQLDataType.bigInteger)},'
+          '${PostgreSQLFormat.id('bi', type: PgDataType.bigInteger)},'
           '${PostgreSQLFormat.id('bl')},'
-          '${PostgreSQLFormat.id('si', type: PostgreSQLDataType.smallInteger)},'
+          '${PostgreSQLFormat.id('si', type: PgDataType.smallInteger)},'
           '${PostgreSQLFormat.id('t')},'
-          '${PostgreSQLFormat.id('f', type: PostgreSQLDataType.real)},'
+          '${PostgreSQLFormat.id('f', type: PgDataType.real)},'
           '${PostgreSQLFormat.id('d')},'
-          '${PostgreSQLFormat.id('dt', type: PostgreSQLDataType.date)},'
+          '${PostgreSQLFormat.id('dt', type: PgDataType.date)},'
           '${PostgreSQLFormat.id('ts')},'
-          '${PostgreSQLFormat.id('tsz', type: PostgreSQLDataType.timestampWithTimezone)}) returning i,s, bi, bs, bl, si, t, f, d, dt, ts, tsz',
+          '${PostgreSQLFormat.id('tsz', type: PgDataType.timestampWithTimezone)}) returning i,s, bi, bs, bl, si, t, f, d, dt, ts, tsz',
           substitutionValues: {
             'i': 1,
             'bi': 2,


### PR DESCRIPTION
type alias is kept in top-level postgres.dart library.