### PR TITLE
SslMode instead of requireSsl and allowCleartextPassword.

### DIFF
--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
@@ -19,6 +21,14 @@ class PgException implements Exception {
 
   @override
   String toString() => '$severity $message';
+}
+
+/// Exception thrown when server certificate validate failed.
+class BadCertificateException extends PgException {
+  final X509Certificate certificate;
+
+  BadCertificateException(this.certificate)
+      : super('Bad server certificate.', severity: Severity.fatal);
 }
 
 /// Exception thrown by the server.

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -282,8 +282,9 @@ class PgConnectionImplementation extends _PgSessionBase
 
         socket = await SecureSocket.secure(
           socket,
-          onBadCertificate:
-              settings.sslMode.ignoreCertificateIssues ? (_) => true : null,
+          onBadCertificate: settings.sslMode.ignoreCertificateIssues
+              ? (_) => true
+              : (c) => throw BadCertificateException(c),
         ).timeout(settings.connectTimeout);
 
         // We can listen to the secured socket again, the existing subscription is

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -38,7 +38,7 @@ class _ResolvedSettings {
   final String timeZone;
   final Encoding encoding;
 
-  final bool allowCleartextPassword;
+  final SslMode sslMode;
   final ReplicationMode replicationMode;
   final QueryMode queryMode;
 
@@ -59,13 +59,9 @@ class _ResolvedSettings {
         transformer = settings?.transformer,
         replicationMode = settings?.replicationMode ?? ReplicationMode.none,
         queryMode = settings?.queryMode ?? QueryMode.extended,
-        allowCleartextPassword = settings?.allowCleartextPassword ?? false,
+        sslMode = settings?.sslMode ?? SslMode.require,
         allowSuperfluousParameters =
             settings?.allowSuperfluousParameters ?? false;
-
-  bool onBadSslCertificate(X509Certificate certificate) {
-    return settings?.onBadSslCertificate?.call(certificate) ?? false;
-  }
 }
 
 abstract class _PgSessionBase implements PgSession {
@@ -270,34 +266,34 @@ class PgConnectionImplementation extends _PgSessionBase
       onError: sslCompleter.completeError,
     );
 
-    // Query if SSL is possible by sending a SSLRequest message
-    final byteBuffer = ByteData(8);
-    byteBuffer.setUint32(0, 8);
-    byteBuffer.setUint32(4, 80877103);
-    socket.add(byteBuffer.buffer.asUint8List());
-
-    final byte = await sslCompleter.future.timeout(settings.connectTimeout);
-
     Stream<Uint8List> adaptedStream;
+    if (settings.sslMode != SslMode.disable) {
+      // Query if SSL is possible by sending a SSLRequest message
+      final byteBuffer = ByteData(8);
+      byteBuffer.setUint32(0, 8);
+      byteBuffer.setUint32(4, 80877103);
+      socket.add(byteBuffer.buffer.asUint8List());
 
-    if (byte == $S) {
-      // SSL is supported, upgrade!
-      subscription.pause();
+      final byte = await sslCompleter.future.timeout(settings.connectTimeout);
 
-      socket = await SecureSocket.secure(
-        socket,
-        onBadCertificate: settings.onBadSslCertificate,
-      ).timeout(settings.connectTimeout);
+      if (byte == $S) {
+        // SSL is supported, upgrade!
+        subscription.pause();
 
-      // We can listen to the secured socket again, the existing subscription is
-      // ignored.
-      adaptedStream = socket;
-    } else {
-      // This server does not support SSL
-      if (settings.endpoint.requireSsl) {
+        socket = await SecureSocket.secure(
+          socket,
+          onBadCertificate:
+              settings.sslMode.ignoreCertificateIssues ? (_) => true : null,
+        ).timeout(settings.connectTimeout);
+
+        // We can listen to the secured socket again, the existing subscription is
+        // ignored.
+        adaptedStream = socket;
+      } else {
+        // This server does not support SSL
         throw PgException('Server does not support SSL, but it was required.');
       }
-
+    } else {
       // We've listened to the stream already and sockets are single-subscription
       // streams. Expose it as a new stream.
       adaptedStream = SubscriptionStream(subscription);
@@ -354,7 +350,7 @@ class PgConnectionImplementation extends _PgSessionBase
         replication: _settings.replicationMode,
       ));
 
-      return result._done.future;
+      return result._done.future.timeout(_settings.connectTimeout);
     });
   }
 
@@ -981,7 +977,7 @@ class _AuthenticationProcedure extends _PendingOperation {
           _initializeAuthenticate(message, AuthenticationScheme.md5);
           break;
         case AuthenticationMessage.KindClearTextPassword:
-          if (!connection._settings.allowCleartextPassword) {
+          if (!connection._settings.sslMode.allowCleartextPassword) {
             _done.completeError(
               PgServerException(
                   'Refused to send clear text password to server'),

--- a/test/connection_test.dart
+++ b/test/connection_test.dart
@@ -135,7 +135,7 @@ void main() {
     });
 
     test('Connect with md5 or scram-sha-256 auth required', () async {
-      conn = await server.newPostgreSQLConnection();
+      conn = await server.newPostgreSQLConnection(sslMode: SslMode.disable);
 
       await conn.open();
 
@@ -143,7 +143,7 @@ void main() {
     });
 
     test('SSL Connect with md5 or scram-sha-256 auth required', () async {
-      conn = await server.newPostgreSQLConnection(useSSL: true);
+      conn = await server.newPostgreSQLConnection(sslMode: SslMode.require);
 
       await conn.open();
 
@@ -158,13 +158,13 @@ void main() {
 
     test('Connect with no auth required', () async {
       conn = await server.newPostgreSQLConnection(
-        endpoint: PgEndpoint(
-          host: 'localhost',
-          database: 'dart_test',
-          port: await server.port,
-          username: 'darttrust',
-        ),
-      );
+          endpoint: PgEndpoint(
+            host: 'localhost',
+            database: 'dart_test',
+            port: await server.port,
+            username: 'darttrust',
+          ),
+          sslMode: SslMode.disable);
       await conn.open();
       expect(await conn.execute('select 1'), equals(1));
     });
@@ -177,6 +177,7 @@ void main() {
           port: await server.port,
           username: 'dart',
         ),
+        sslMode: SslMode.disable,
       );
       try {
         await conn.open();
@@ -198,8 +199,8 @@ void main() {
           database: 'dart_test',
           port: await server.port,
           username: 'darttrust',
-          requireSsl: true,
         ),
+        sslMode: SslMode.require,
       );
       await conn.open();
 
@@ -417,7 +418,7 @@ void main() {
 
     test('Starting transaction while opening connection triggers error',
         () async {
-      conn = await server.newPostgreSQLConnection(useSSL: true);
+      conn = await server.newPostgreSQLConnection(sslMode: SslMode.require);
       openFuture = conn.open();
 
       try {
@@ -432,7 +433,7 @@ void main() {
 
     test('SSL Starting transaction while opening connection triggers error',
         () async {
-      conn = await server.newPostgreSQLConnection(useSSL: true);
+      conn = await server.newPostgreSQLConnection(sslMode: SslMode.require);
       openFuture = conn.open();
 
       try {
@@ -458,6 +459,7 @@ void main() {
             username: 'dart',
             password: 'notdart',
           ),
+          sslMode: SslMode.disable,
         );
         await conn.open();
         expect(true, false);
@@ -479,8 +481,8 @@ void main() {
             port: await server.port,
             username: 'dart',
             password: 'notdart',
-            requireSsl: true,
           ),
+          sslMode: SslMode.require,
         );
         await conn.open();
         expect(true, false);
@@ -639,6 +641,7 @@ void main() {
         conn = await server.newPostgreSQLConnection(
           endpoint:
               PgEndpoint(host: 'localhost', database: 'dart_test', port: port),
+          sslMode: SslMode.disable,
         );
         await conn.open();
         expect(true, false);
@@ -661,8 +664,8 @@ void main() {
             host: 'localhost',
             database: 'dart_test',
             port: port,
-            requireSsl: true,
           ),
+          sslMode: SslMode.require,
         );
         await conn.open();
         expect(true, false);
@@ -694,6 +697,7 @@ void main() {
             database: 'dart_test',
           ),
           connectTimeout: Duration(seconds: 2),
+          sslMode: SslMode.disable,
         );
         await conn.open();
         fail('unreachable');
@@ -723,9 +727,9 @@ void main() {
             host: 'localhost',
             port: port,
             database: 'dart_test',
-            requireSsl: true,
           ),
           connectTimeout: Duration(seconds: 2),
+          sslMode: SslMode.require,
         );
         await conn.open();
         fail('unreachable');

--- a/test/non_ascii_connection_strings_test.dart
+++ b/test/non_ascii_connection_strings_test.dart
@@ -1,4 +1,5 @@
 import 'package:postgres/legacy.dart';
+import 'package:postgres/postgres.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
@@ -20,8 +21,7 @@ void main() {
       });
 
       test('- Connect with non-ascii connection string', () async {
-        conn =
-            await server.newPostgreSQLConnection(allowClearTextPassword: true);
+        conn = await server.newPostgreSQLConnection(sslMode: SslMode.disable);
         await conn!.open();
         final res = await conn!.query('select 1;');
         expect(res.length, 1);

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -5,10 +5,7 @@ import 'package:test/test.dart';
 
 import 'docker.dart';
 
-final _sessionSettings = PgSessionSettings(
-  // To test SSL, we're running postgres with a self-signed certificate.
-  onBadSslCertificate: (cert) => true,
-);
+final _sessionSettings = PgSessionSettings();
 
 void main() {
   withPostgresServer('generic', (server) {

--- a/test/v3_close_test.dart
+++ b/test/v3_close_test.dart
@@ -12,16 +12,12 @@ void main() {
       conn1 = await PgConnection.open(
         await server.endpoint(),
         sessionSettings: PgSessionSettings(
-          onBadSslCertificate: (cert) => true,
-          //transformer: _loggingTransformer('c1'),
-        ),
+            //transformer: _loggingTransformer('c1'),
+            ),
       );
 
       conn2 = await PgConnection.open(
         await server.endpoint(),
-        sessionSettings: PgSessionSettings(
-          onBadSslCertificate: (cert) => true,
-        ),
       );
     });
 

--- a/test/v3_logical_replication_test.dart
+++ b/test/v3_logical_replication_test.dart
@@ -70,7 +70,6 @@ void main() {
         ),
         sessionSettings: PgSessionSettings(
             replicationMode: ReplicationMode.logical,
-            onBadSslCertificate: (cert) => true,
             transformer: serverMessagesInterceptor.transformer,
             queryMode: QueryMode.simple),
       );
@@ -80,9 +79,6 @@ void main() {
       // stream
       changesConn = await PgConnection.open(
         await server.endpoint(),
-        sessionSettings: PgSessionSettings(
-          onBadSslCertificate: (cert) => true,
-        ),
       );
 
       // create testing tables

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -9,9 +9,6 @@ import 'package:test/test.dart';
 import 'docker.dart';
 
 final _sessionSettings = PgSessionSettings(
-  // To test SSL, we're running postgres with a self-signed certificate.
-  onBadSslCertificate: (cert) => true,
-
   transformer: loggingTransformer('conn'),
 );
 
@@ -422,7 +419,6 @@ void main() {
         await server.endpoint(),
         sessionSettings: PgSessionSettings(
           transformer: transformer,
-          onBadSslCertificate: (_) => true,
         ),
       );
       addTearDown(connection.close);
@@ -442,7 +438,6 @@ void main() {
         await server.endpoint(),
         sessionSettings: PgSessionSettings(
           transformer: loggingTransformer('c1'),
-          onBadSslCertificate: (cert) => true,
         ),
       );
 
@@ -450,7 +445,6 @@ void main() {
         await server.endpoint(),
         sessionSettings: PgSessionSettings(
           transformer: loggingTransformer('c2'),
-          onBadSslCertificate: (cert) => true,
         ),
       );
     });


### PR DESCRIPTION
- This follows the other Postgres client libraries better.
- /cc @simolus3 to have a second pair of eyes on the `connection.dart` changes: it triggers SSL connection unless `sslMode = SslMode.disable`, most of it is indent changes + how the `adaptedStream` is initialized.