### PR TITLE
Revert default query escape.

### DIFF
--- a/lib/src/v3/query_description.dart
+++ b/lib/src/v3/query_description.dart
@@ -52,7 +52,7 @@ class InternalQueryDescription implements PgSql {
 
   factory InternalQueryDescription.wrap(Object query) {
     if (query is String) {
-      return InternalQueryDescription.map(query);
+      return InternalQueryDescription.direct(query);
     } else if (query is InternalQueryDescription) {
       return query;
     } else {

--- a/test/transaction_test.dart
+++ b/test/transaction_test.dart
@@ -23,7 +23,8 @@ void main() {
       await conn.execute('INSERT INTO t (id) VALUES (1)');
 
       final outValue = await conn.runTx((ctx) async {
-        return await ctx.execute('SELECT * FROM t WHERE id = @id:int4 LIMIT 1',
+        return await ctx.execute(
+            PgSql.map('SELECT * FROM t WHERE id = @id:int4 LIMIT 1'),
             parameters: {'id': 1});
       });
 
@@ -491,7 +492,7 @@ void main() {
 
         // The mismatched type is caught in Dart, but unawaited here
         expect(
-            c.execute('INSERT INTO t (id) VALUES (@id:int4)',
+            c.execute(PgSql.map('INSERT INTO t (id) VALUES (@id:int4)'),
                 parameters: {'id': 'foobar'}),
             throwsA(isA<FormatException>()));
 
@@ -624,7 +625,7 @@ void main() {
     test('can start transactions manually', () async {
       await conn.execute('BEGIN');
       await conn.execute(
-        'INSERT INTO t VALUES (@a:int4)',
+        PgSql.map('INSERT INTO t VALUES (@a:int4)'),
         parameters: {'a': 123},
       );
       await conn.execute('ROLLBACK');


### PR DESCRIPTION
`PgSql` documentation says that by default queries are not escaped, but at one point we have reverted back to mapping. I think with the current legacy connection wrapper, we can revert that change and do not touch the queries by default. What do you think @simolus3?

As we are at it: what would be be a better name here?
- `Sql` or `Query`?
- `*.map` or `*.named`?

I have slight biases for the second options...