### PR TITLE
Optimize type exports for the default postgres library.

### DIFF
--- a/lib/legacy.dart
+++ b/lib/legacy.dart
@@ -2,9 +2,6 @@ library legacy;
 
 import 'src/types.dart';
 
-export 'src/exceptions.dart';
-export 'src/replication.dart' show ReplicationMode;
-export 'src/types.dart';
 export 'src/v2/connection.dart';
 export 'src/v2/execution_context.dart';
 export 'src/v2/substituter.dart';

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:postgres/legacy.dart';
+import 'package:postgres/postgres.dart';
 import 'package:postgres/src/binary_codec.dart';
 import 'package:test/test.dart';
 

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:postgres/legacy.dart';
+import 'package:postgres/postgres.dart';
 import 'package:postgres/src/binary_codec.dart';
 import 'package:postgres/src/text_codec.dart';
 import 'package:test/test.dart';

--- a/test/interpolation_test.dart
+++ b/test/interpolation_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:postgres/legacy.dart';
+import 'package:postgres/postgres.dart';
 import 'package:postgres/src/v2/query.dart';
 import 'package:test/test.dart';
 

--- a/test/logical_replication_test.dart
+++ b/test/logical_replication_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:postgres/legacy.dart';
 import 'package:postgres/messages.dart';
+import 'package:postgres/postgres.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 

--- a/test/query_reuse_test.dart
+++ b/test/query_reuse_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:mirrors';
 
 import 'package:postgres/legacy.dart';
+import 'package:postgres/postgres.dart';
 import 'package:postgres/src/v2/query_cache.dart';
 import 'package:test/test.dart';
 

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -1,4 +1,5 @@
 import 'package:postgres/legacy.dart';
+import 'package:postgres/postgres.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';


### PR DESCRIPTION
Otherwise `legacy.dart` will own shared types like exceptions, type/typed value and others, and we want to display everything under `postgres.dart`.