### PR TITLE
Transaction mode (isolation, access, deferrable).

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'src/replication.dart';
@@ -448,12 +447,12 @@ enum QueryMode {
 enum IsolationLevel {
   /// A statement can only see rows committed before it began.
   /// This is the default.
-  readCommitted('READ COMMITTED'),
+  readCommitted._('READ COMMITTED'),
 
   /// All statements of the current transaction can only see rows committed
   /// before the first query or data-modification statement was executed in
   /// this transaction.
-  repeatableRead('REPEATABLE READ'),
+  repeatableRead._('REPEATABLE READ'),
 
   /// All statements of the current transaction can only see rows committed
   /// before the first query or data-modification statement was executed in
@@ -461,25 +460,25 @@ enum IsolationLevel {
   /// serializable transactions would create a situation which could not have
   /// occurred for any serial (one-at-a-time) execution of those transactions,
   /// one of them will be rolled back with a serialization_failure error.
-  serializable('SERIALIZABLE'),
+  serializable._('SERIALIZABLE'),
 
   /// One transaction may see uncommitted changes made by some other transaction.
   /// In PostgreSQL READ UNCOMMITTED is treated as READ COMMITTED.
-  readUncommitted('READ UNCOMMITTED'),
+  readUncommitted._('READ UNCOMMITTED'),
   ;
 
-  /// The SQL identifier of the isolation level including "ISOLATION LEVEL" prefix.
-  final String _sqlName;
+  /// The SQL identifier of the isolation level including "ISOLATION LEVEL" prefix
+  /// and leading space.
+  final String sqlPart;
 
-  const IsolationLevel(String identifier)
-      : _sqlName = 'ISOLATION LEVEL $identifier';
+  const IsolationLevel._(String value) : sqlPart = ' ISOLATION LEVEL $value';
 }
 
 /// The transaction access mode determines whether the transaction is read/write
 /// or read-only.
 enum AccessMode {
   /// Read/write is the default.
-  readWrite('READ WRITE'),
+  readWrite._('READ WRITE'),
 
   /// When a transaction is read-only, the following SQL commands are disallowed:
   /// INSERT, UPDATE, DELETE, MERGE, and COPY FROM if the table they would write
@@ -487,12 +486,13 @@ enum AccessMode {
   /// GRANT, REVOKE, TRUNCATE; and EXPLAIN ANALYZE and EXECUTE if the command
   /// they would execute is among those listed. This is a high-level notion of
   /// read-only that does not prevent all writes to disk.
-  readOnly('READ ONLY'),
+  readOnly._('READ ONLY'),
   ;
 
-  final String _sqlName;
+  /// The SQL identifier of the access mode including leading space.
+  final String sqlPart;
 
-  const AccessMode(this._sqlName);
+  const AccessMode._(String value) : sqlPart = ' $value';
 }
 
 /// The characteristics of the current transaction.
@@ -519,25 +519,4 @@ class TransactionMode {
     this.accessMode,
     this.deferrable,
   });
-
-  late final isEmpty =
-      isolationLevel == null && accessMode == null && deferrable == null;
-  late final isNotEmpty = !isEmpty;
-
-  // ignore: invalid_internal_annotation
-  @internal
-  void appendToStringBuffer(StringBuffer sb) {
-    if (isolationLevel != null) {
-      sb.write(' ');
-      sb.write(isolationLevel!._sqlName);
-    }
-    if (accessMode != null) {
-      sb.write(' ');
-      sb.write(accessMode!._sqlName);
-    }
-    if (deferrable != null) {
-      if (!deferrable!) sb.write(' NOT');
-      sb.write(' DEFERRABLE');
-    }
-  }
 }

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 
 import 'src/replication.dart';
@@ -469,9 +470,10 @@ enum IsolationLevel {
 
   /// The SQL identifier of the isolation level including "ISOLATION LEVEL" prefix
   /// and leading space.
-  final String sqlPart;
+  @internal
+  final String queryPart;
 
-  const IsolationLevel._(String value) : sqlPart = ' ISOLATION LEVEL $value';
+  const IsolationLevel._(String value) : queryPart = ' ISOLATION LEVEL $value';
 }
 
 /// The transaction access mode determines whether the transaction is read/write
@@ -490,9 +492,10 @@ enum AccessMode {
   ;
 
   /// The SQL identifier of the access mode including leading space.
-  final String sqlPart;
+  @internal
+  final String queryPart;
 
-  const AccessMode._(String value) : sqlPart = ' $value';
+  const AccessMode._(String value) : queryPart = ' $value';
 }
 
 /// The deferrable mode of the transaction.
@@ -511,9 +514,10 @@ enum DeferrableMode {
   ;
 
   /// The SQL identifier of the deferrable mode including leading space.
-  final String sqlPart;
+  @internal
+  final String queryPart;
 
-  const DeferrableMode._(String value) : sqlPart = ' $value';
+  const DeferrableMode._(String value) : queryPart = ' $value';
 }
 
 /// The characteristics of the current transaction.

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -495,6 +495,27 @@ enum AccessMode {
   const AccessMode._(String value) : sqlPart = ' $value';
 }
 
+/// The deferrable mode of the transaction.
+enum DeferrableMode {
+  /// The DEFERRABLE transaction property has no effect unless the transaction
+  /// is also SERIALIZABLE and READ ONLY. When all three of these properties
+  /// are selected for a transaction, the transaction may block when first
+  /// acquiring its snapshot, after which it is able to run without the normal
+  /// overhead of a SERIALIZABLE transaction and without any risk of contributing
+  /// to or being canceled by a serialization failure. This mode is well suited
+  /// for long-running reports or backups.
+  deferrable._('DEFERRABLE'),
+
+  /// The default mode.
+  notDeferrable._('NOT DEFERRABLE'),
+  ;
+
+  /// The SQL identifier of the deferrable mode including leading space.
+  final String sqlPart;
+
+  const DeferrableMode._(String value) : sqlPart = ' $value';
+}
+
 /// The characteristics of the current transaction.
 class TransactionMode {
   /// The isolation level of a transaction determines what data the transaction
@@ -512,7 +533,7 @@ class TransactionMode {
   /// overhead of a SERIALIZABLE transaction and without any risk of contributing
   /// to or being canceled by a serialization failure. This mode is well suited
   /// for long-running reports or backups.
-  final bool? deferrable;
+  final DeferrableMode? deferrable;
 
   TransactionMode({
     this.isolationLevel,

--- a/lib/src/pool/pool_api.dart
+++ b/lib/src/pool/pool_api.dart
@@ -69,6 +69,7 @@ abstract class Pool<L> implements Session, SessionExecutor {
   @override
   Future<R> runTx<R>(
     Future<R> Function(Session session) fn, {
+    TransactionMode? transactionMode,
     L? locality,
   });
 

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -100,10 +100,14 @@ class PoolImplementation<L> implements Pool<L> {
   @override
   Future<R> runTx<R>(
     Future<R> Function(Session session) fn, {
+    TransactionMode? transactionMode,
     L? locality,
   }) {
     return withConnection(
-      (connection) => connection.runTx(fn),
+      (connection) => connection.runTx(
+        fn,
+        transactionMode: transactionMode,
+      ),
       locality: locality,
     );
   }
@@ -212,8 +216,14 @@ class _PoolConnection implements Connection {
   }
 
   @override
-  Future<R> runTx<R>(Future<R> Function(Session session) fn) {
-    return _connection.runTx(fn);
+  Future<R> runTx<R>(
+    Future<R> Function(Session session) fn, {
+    TransactionMode? transactionMode,
+  }) {
+    return _connection.runTx(
+      fn,
+      transactionMode: transactionMode,
+    );
   }
 }
 

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -1030,13 +1030,13 @@ extension on TransactionMode {
 
   void appendToStringBuffer(StringBuffer sb) {
     if (isolationLevel != null) {
-      sb.write(isolationLevel!.sqlPart);
+      sb.write(isolationLevel!.queryPart);
     }
     if (accessMode != null) {
-      sb.write(accessMode!.sqlPart);
+      sb.write(accessMode!.queryPart);
     }
     if (deferrable != null) {
-      sb.write(deferrable!.sqlPart);
+      sb.write(deferrable!.queryPart);
     }
   }
 }

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -1021,3 +1021,23 @@ extension FutureExt<R> on Future<R> {
     return timeout(duration);
   }
 }
+
+extension on TransactionMode {
+  bool get isEmpty =>
+      isolationLevel == null && accessMode == null && deferrable == null;
+
+  bool get isNotEmpty => !isEmpty;
+
+  void appendToStringBuffer(StringBuffer sb) {
+    if (isolationLevel != null) {
+      sb.write(isolationLevel!.sqlPart);
+    }
+    if (accessMode != null) {
+      sb.write(accessMode!.sqlPart);
+    }
+    if (deferrable != null) {
+      if (!deferrable!) sb.write(' NOT');
+      sb.write(' DEFERRABLE');
+    }
+  }
+}

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -1036,8 +1036,7 @@ extension on TransactionMode {
       sb.write(accessMode!.sqlPart);
     }
     if (deferrable != null) {
-      if (!deferrable!) sb.write(' NOT');
-      sb.write(' DEFERRABLE');
+      sb.write(deferrable!.sqlPart);
     }
   }
 }

--- a/test/transaction_test.dart
+++ b/test/transaction_test.dart
@@ -689,4 +689,96 @@ void main() {
       );
     }, skip: !server.useV3);
   });
+
+  withPostgresServer('transaction isolations', (server) {
+    late Connection conn1;
+    late Connection conn2;
+
+    setUp(() async {
+      conn1 = await server.newConnection();
+      conn2 = await server.newConnection();
+      await conn1.execute('CREATE TABLE t (id INT PRIMARY KEY, counter INT)');
+      await conn1.execute('INSERT INTO t VALUES (1, 0)');
+    });
+
+    tearDown(() async {
+      await conn1.execute('DROP TABLE t;');
+      await conn1.close();
+      await conn2.close();
+    });
+
+    test('read committed works as expected', () async {
+      final c1 = Completer();
+      final c2 = Completer();
+      final c3 = Completer();
+      final f1 = Future.microtask(
+        () => conn1.runTx(
+          transactionMode: TransactionMode(
+            isolationLevel: IsolationLevel.readCommitted,
+          ),
+          (session) async {
+            await c2.future;
+            await session
+                .execute('UPDATE t SET counter = counter + 1 WHERE id=1');
+            c1.complete();
+            // await c3.future;
+          },
+        ),
+      );
+      final f2 = Future.microtask(
+        () => conn2.runTx(
+          transactionMode: TransactionMode(
+            isolationLevel: IsolationLevel.readCommitted,
+          ),
+          (session) async {
+            c2.complete();
+            await c1.future;
+            await session
+                .execute('UPDATE t SET counter = counter + 1 WHERE id=1');
+            c3.complete();
+          },
+        ),
+      );
+      await Future.wait([f1, f2]);
+      final rs = await conn1.execute('SELECT * from t WHERE id=1');
+      expect(rs.single, [1, 2]);
+    });
+
+    test('forced serialization failure', () async {
+      final c1 = Completer();
+      final c2 = Completer();
+      final c3 = Completer();
+      final f1 = Future.microtask(
+        () => conn1.runTx(
+          transactionMode: TransactionMode(
+            isolationLevel: IsolationLevel.serializable,
+          ),
+          (session) async {
+            await c2.future;
+            await session
+                .execute('UPDATE t SET counter = counter + 1 WHERE id=1');
+            c1.complete();
+            // await c3.future;
+          },
+        ),
+      );
+      final f2 = Future.microtask(
+        () => conn2.runTx(
+          transactionMode: TransactionMode(
+            isolationLevel: IsolationLevel.serializable,
+          ),
+          (session) async {
+            c2.complete();
+            await c1.future;
+            await session
+                .execute('UPDATE t SET counter = counter + 1 WHERE id=1');
+            c3.complete();
+          },
+        ),
+      );
+      expectLater(() => Future.wait([f1, f2]), throwsA(isA<ServerException>()));
+      final rs = await conn1.execute('SELECT * from t WHERE id=1');
+      expect(rs.single, [1, 1]);
+    });
+  });
 }


### PR DESCRIPTION
- Possibly closes #79.
- cc @simolus3 @rubenferreira97

Things to consider:
- The naming is a bit long, maybe it could be `TxMode` instead of `TransactionMode`, and `Isolation` instead of `IsolationLevel`?
- I'm undecided whether this should be a separate parameter, or part of `SessionSettings` that `run` and `runTx` may get (and merge with connection-level settings, where some parts of the current `SessionSettings` may become a separate `ConnectionSettings`....