### PR TITLE
Session-, Connection-, Transaction- and Pool- Settings.

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -137,7 +137,10 @@ abstract class SessionExecutor {
   ///
   /// Returns the result (either the value or an error) of invoking [fn]. No
   /// updates will be reverted in the event of an error.
-  Future<R> run<R>(Future<R> Function(Session session) fn);
+  Future<R> run<R>(
+    Future<R> Function(Session session) fn,
+    // {SessionSettings? sessionSettings,}
+  );
 
   /// Obtains a [Session] running in a transaction and calls [fn] with it.
   ///
@@ -149,6 +152,7 @@ abstract class SessionExecutor {
   Future<R> runTx<R>(
     Future<R> Function(Session session) fn, {
     TransactionMode? transactionMode,
+    // SessionSettings? sessionSettings,
   });
 
   /// Closes this session, cleaning up resources and forbiding further calls to
@@ -159,10 +163,10 @@ abstract class SessionExecutor {
 abstract class Connection implements Session, SessionExecutor {
   static Future<Connection> open(
     Endpoint endpoint, {
-    SessionSettings? sessionSettings,
+    ConnectionSettings? connectionSettings,
   }) {
     return PgConnectionImplementation.connect(endpoint,
-        sessionSettings: sessionSettings);
+        connectionSettings: connectionSettings);
   }
 
   Channels get channels;
@@ -363,18 +367,10 @@ enum SslMode {
   bool get allowCleartextPassword => this == SslMode.disable;
 }
 
-final class SessionSettings {
+final class ConnectionSettings extends SessionSettings {
   final String? applicationName;
-
-  // Duration(seconds: 15)
-  final Duration? connectTimeout;
-  // Duration(minutes: 5)
-  final Duration? queryTimeout;
-
   final String? timeZone;
-
   final Encoding? encoding;
-
   final SslMode? sslMode;
 
   /// An optional [StreamChannelTransformer] sitting behind the postgres client
@@ -401,7 +397,28 @@ final class SessionSettings {
   /// For more info, see [Streaming Replication Protocol]
   ///
   /// [Streaming Replication Protocol]: https://www.postgresql.org/docs/current/protocol-replication.html
-  final ReplicationMode replicationMode;
+  final ReplicationMode? replicationMode;
+
+  ConnectionSettings({
+    this.applicationName,
+    this.timeZone,
+    this.encoding,
+    this.sslMode,
+    this.transformer,
+    this.replicationMode,
+    super.connectTimeout,
+    super.queryTimeout,
+    super.queryMode,
+    super.allowSuperfluousParameters,
+  });
+}
+
+final class SessionSettings {
+  // Duration(seconds: 15)
+  final Duration? connectTimeout;
+
+  // Duration(minutes: 5)
+  final Duration? queryTimeout;
 
   /// The Query Execution Mode
   ///
@@ -410,21 +427,15 @@ final class SessionSettings {
   /// (e.g. in replication mode or with proxies such as PGBouncer), hence the
   /// the Simple one would be the only viable option. Unless necessary, always
   /// prefer using [QueryMode.extended].
-  final QueryMode queryMode;
+  final QueryMode? queryMode;
 
   /// Override the default query map check if superfluous parameters are found.
   final bool? allowSuperfluousParameters;
 
   SessionSettings({
-    this.applicationName,
     this.connectTimeout,
     this.queryTimeout,
-    this.timeZone,
-    this.encoding,
-    this.sslMode,
-    this.transformer,
-    this.replicationMode = ReplicationMode.none,
-    this.queryMode = QueryMode.extended,
+    this.queryMode,
     this.allowSuperfluousParameters,
   });
 }

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -151,8 +151,7 @@ abstract class SessionExecutor {
   /// transaction is active.
   Future<R> runTx<R>(
     Future<R> Function(Session session) fn, {
-    TransactionMode? transactionMode,
-    // SessionSettings? sessionSettings,
+    TransactionSettings? settings,
   });
 
   /// Closes this session, cleaning up resources and forbiding further calls to
@@ -163,10 +162,10 @@ abstract class SessionExecutor {
 abstract class Connection implements Session, SessionExecutor {
   static Future<Connection> open(
     Endpoint endpoint, {
-    ConnectionSettings? connectionSettings,
+    ConnectionSettings? settings,
   }) {
     return PgConnectionImplementation.connect(endpoint,
-        connectionSettings: connectionSettings);
+        connectionSettings: settings);
   }
 
   Channels get channels;
@@ -367,7 +366,7 @@ enum SslMode {
   bool get allowCleartextPassword => this == SslMode.disable;
 }
 
-final class ConnectionSettings extends SessionSettings {
+class ConnectionSettings extends SessionSettings {
   final String? applicationName;
   final String? timeZone;
   final Encoding? encoding;
@@ -413,7 +412,7 @@ final class ConnectionSettings extends SessionSettings {
   });
 }
 
-final class SessionSettings {
+class SessionSettings {
   // Duration(seconds: 15)
   final Duration? connectTimeout;
 
@@ -527,7 +526,7 @@ enum DeferrableMode {
 }
 
 /// The characteristics of the current transaction.
-class TransactionMode {
+class TransactionSettings extends SessionSettings {
   /// The isolation level of a transaction determines what data the transaction
   /// can see when other transactions are running concurrently.
   final IsolationLevel? isolationLevel;
@@ -545,9 +544,13 @@ class TransactionMode {
   /// for long-running reports or backups.
   final DeferrableMode? deferrable;
 
-  TransactionMode({
+  TransactionSettings({
     this.isolationLevel,
     this.accessMode,
     this.deferrable,
+    super.connectTimeout,
+    super.queryTimeout,
+    super.queryMode,
+    super.allowSuperfluousParameters,
   });
 }

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -138,9 +138,9 @@ abstract class SessionExecutor {
   /// Returns the result (either the value or an error) of invoking [fn]. No
   /// updates will be reverted in the event of an error.
   Future<R> run<R>(
-    Future<R> Function(Session session) fn,
-    // {SessionSettings? sessionSettings,}
-  );
+    Future<R> Function(Session session) fn, {
+    SessionSettings? settings,
+  });
 
   /// Obtains a [Session] running in a transaction and calls [fn] with it.
   ///

--- a/lib/src/pool/pool_api.dart
+++ b/lib/src/pool/pool_api.dart
@@ -81,6 +81,7 @@ abstract class Pool<L> implements Session, SessionExecutor {
   @override
   Future<R> run<R>(
     Future<R> Function(Session session) fn, {
+    SessionSettings? settings,
     L? locality,
   });
 

--- a/lib/src/pool/pool_api.dart
+++ b/lib/src/pool/pool_api.dart
@@ -46,24 +46,24 @@ final class PoolSettings {
 abstract class Pool<L> implements Session, SessionExecutor {
   factory Pool.withSelector(
     EndpointSelector<L> selector, {
-    SessionSettings? sessionSettings,
+    ConnectionSettings? connectionSettings,
     PoolSettings? poolSettings,
   }) =>
       PoolImplementation(
         selector,
-        sessionSettings,
+        connectionSettings,
         poolSettings,
       );
 
   /// Creates a connection pool from a fixed list of endpoints.
   factory Pool.withEndpoints(
     List<Endpoint> endpoints, {
-    SessionSettings? sessionSettings,
+    ConnectionSettings? connectionSettings,
     PoolSettings? poolSettings,
   }) =>
       PoolImplementation(
         roundRobinSelector(endpoints),
-        sessionSettings,
+        connectionSettings,
         poolSettings,
       );
 
@@ -74,7 +74,7 @@ abstract class Pool<L> implements Session, SessionExecutor {
   /// another [withConnection] call later.
   Future<R> withConnection<R>(
     Future<R> Function(Connection connection) fn, {
-    SessionSettings? sessionSettings,
+    ConnectionSettings? connectionSettings,
     L? locality,
   });
 

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -91,10 +91,11 @@ class PoolImplementation<L> implements Pool<L> {
   @override
   Future<R> run<R>(
     Future<R> Function(Session session) fn, {
+    SessionSettings? settings,
     L? locality,
   }) {
     return withConnection(
-      (connection) => connection.run(fn),
+      (connection) => connection.run(fn, settings: settings),
       locality: locality,
     );
   }
@@ -252,9 +253,12 @@ class _PoolConnection implements Connection {
   }
 
   @override
-  Future<R> run<R>(Future<R> Function(Session session) fn) {
+  Future<R> run<R>(
+    Future<R> Function(Session session) fn, {
+    SessionSettings? settings,
+  }) {
     // TODO: increment query count on session callbacks
-    return _connection.run(fn);
+    return _connection.run(fn, settings: settings);
   }
 
   @override

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:pool/pool.dart' as pool;
+import 'package:postgres/src/v3/resolved_settings.dart';
 
 import '../../postgres.dart';
 import '../v3/connection.dart';
@@ -139,7 +140,8 @@ class PoolImplementation<L> implements Pool<L> {
           selection.endpoint,
           await PgConnectionImplementation.connect(
             selection.endpoint,
-            connectionSettings: connectionSettings ?? this.settings,
+            connectionSettings:
+                ResolvedConnectionSettings(connectionSettings, this.settings),
           ),
         );
         _connections.add(connection);

--- a/lib/src/v2/connection.dart
+++ b/lib/src/v2/connection.dart
@@ -9,7 +9,7 @@ import 'package:buffer/buffer.dart';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
-import '../../postgres.dart' show Endpoint, Notification, SessionSettings;
+import '../../postgres.dart' show ConnectionSettings, Endpoint, Notification;
 import '../auth/auth.dart';
 import '../client_messages.dart';
 import '../exceptions.dart';
@@ -41,10 +41,10 @@ class PostgreSQLConnection extends Object
   /// that is backed by the new v3 implementation.
   static PostgreSQLConnection withV3(
     Endpoint endpoint, {
-    SessionSettings? sessionSettings,
+    ConnectionSettings? connectionSettings,
   }) {
     return WrappedPostgreSQLConnection(
-        endpoint, sessionSettings ?? SessionSettings());
+        endpoint, connectionSettings ?? ConnectionSettings());
   }
 
   /// Creates an instance of [PostgreSQLConnection].

--- a/lib/src/v2/v2_v3_delegate.dart
+++ b/lib/src/v2/v2_v3_delegate.dart
@@ -128,7 +128,7 @@ class WrappedPostgreSQLConnection
     _hasConnectedPreviously = true;
     _connection = await Connection.open(
       _endpoint,
-      connectionSettings: _connectionSettings,
+      settings: _connectionSettings,
     );
   }
 

--- a/lib/src/v2/v2_v3_delegate.dart
+++ b/lib/src/v2/v2_v3_delegate.dart
@@ -74,11 +74,11 @@ class WrappedPostgreSQLConnection
     with _DelegatingContext
     implements PostgreSQLConnection {
   final Endpoint _endpoint;
-  final SessionSettings _sessionSettings;
+  final ConnectionSettings _connectionSettings;
   Connection? _connection;
   bool _hasConnectedPreviously = false;
 
-  WrappedPostgreSQLConnection(this._endpoint, this._sessionSettings);
+  WrappedPostgreSQLConnection(this._endpoint, this._connectionSettings);
 
   @override
   Session? get _session => _connection;
@@ -128,7 +128,7 @@ class WrappedPostgreSQLConnection
     _hasConnectedPreviously = true;
     _connection = await Connection.open(
       _endpoint,
-      sessionSettings: _sessionSettings,
+      connectionSettings: _connectionSettings,
     );
   }
 

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -172,7 +172,9 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
     Endpoint endpoint, {
     ConnectionSettings? connectionSettings,
   }) async {
-    final settings = ResolvedConnectionSettings(connectionSettings);
+    final settings = connectionSettings is ResolvedConnectionSettings
+        ? connectionSettings
+        : ResolvedConnectionSettings(connectionSettings, null);
     var channel = await _connect(endpoint, settings);
 
     if (_debugLog) {

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -27,7 +27,7 @@ String identifier(String source) {
 
 class _ResolvedSettings {
   final Endpoint endpoint;
-  final SessionSettings? settings;
+  final ConnectionSettings? settings;
 
   final String username;
   final String password;
@@ -207,9 +207,9 @@ abstract class _PgSessionBase implements Session {
 class PgConnectionImplementation extends _PgSessionBase implements Connection {
   static Future<PgConnectionImplementation> connect(
     Endpoint endpoint, {
-    SessionSettings? sessionSettings,
+    ConnectionSettings? connectionSettings,
   }) async {
-    final settings = _ResolvedSettings(endpoint, sessionSettings);
+    final settings = _ResolvedSettings(endpoint, connectionSettings);
     var channel = await _connect(settings);
 
     if (_debugLog) {

--- a/lib/src/v3/resolved_settings.dart
+++ b/lib/src/v3/resolved_settings.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+import 'package:postgres/messages.dart';
+import 'package:stream_channel/stream_channel.dart';
+
+import '../../postgres.dart';
+
+class ResolvedSessionSettings implements SessionSettings {
+  @override
+  final Duration connectTimeout;
+  @override
+  final Duration queryTimeout;
+  @override
+  final QueryMode queryMode;
+  @override
+  final bool allowSuperfluousParameters;
+
+  ResolvedSessionSettings(SessionSettings? settings)
+      : connectTimeout = settings?.connectTimeout ?? Duration(seconds: 15),
+        queryTimeout = settings?.queryTimeout ?? Duration(minutes: 5),
+        queryMode = settings?.queryMode ?? QueryMode.extended,
+        allowSuperfluousParameters =
+            settings?.allowSuperfluousParameters ?? false;
+}
+
+class ResolvedConnectionSettings extends ResolvedSessionSettings
+    implements ConnectionSettings {
+  @override
+  final String? applicationName;
+  @override
+  final String timeZone;
+  @override
+  final Encoding encoding;
+  @override
+  final SslMode sslMode;
+  @override
+  final StreamChannelTransformer<Message, Message>? transformer;
+  @override
+  final ReplicationMode replicationMode;
+
+  ResolvedConnectionSettings(ConnectionSettings? super.settings)
+      : applicationName = settings?.applicationName,
+        timeZone = settings?.timeZone ?? 'UTC',
+        encoding = settings?.encoding ?? utf8,
+        sslMode = settings?.sslMode ?? SslMode.require,
+        transformer = settings?.transformer,
+        replicationMode = settings?.replicationMode ?? ReplicationMode.none;
+}
+
+class ResolvedPoolSettings extends ResolvedConnectionSettings
+    implements PoolSettings {
+  @override
+  final int maxConnectionCount;
+  @override
+  final Duration maxConnectionAge;
+  @override
+  final Duration maxSessionUse;
+  @override
+  final int maxQueryCount;
+
+  ResolvedPoolSettings(PoolSettings? super.settings)
+      : maxConnectionCount = settings?.maxConnectionCount ?? 1,
+        maxConnectionAge = settings?.maxConnectionAge ?? Duration(hours: 12),
+        maxSessionUse = settings?.maxSessionUse ?? Duration(hours: 4),
+        maxQueryCount = settings?.maxQueryCount ?? 100000;
+}

--- a/lib/src/v3/resolved_settings.dart
+++ b/lib/src/v3/resolved_settings.dart
@@ -64,3 +64,18 @@ class ResolvedPoolSettings extends ResolvedConnectionSettings
         maxSessionUse = settings?.maxSessionUse ?? Duration(hours: 4),
         maxQueryCount = settings?.maxQueryCount ?? 100000;
 }
+
+class ResolvedTransactionSettings extends ResolvedSessionSettings
+    implements TransactionSettings {
+  @override
+  final IsolationLevel? isolationLevel;
+  @override
+  final AccessMode? accessMode;
+  @override
+  final DeferrableMode? deferrable;
+
+  ResolvedTransactionSettings(TransactionSettings? super.settings)
+      : isolationLevel = settings?.isolationLevel,
+        accessMode = settings?.accessMode,
+        deferrable = settings?.deferrable;
+}

--- a/test/docker.dart
+++ b/test/docker.dart
@@ -82,7 +82,7 @@ class PostgresServer {
   }) async {
     return Connection.open(
       await endpoint(),
-      sessionSettings: SessionSettings(
+      connectionSettings: ConnectionSettings(
         connectTimeout: Duration(seconds: 3),
         queryTimeout: Duration(seconds: 3),
         replicationMode: replicationMode,
@@ -102,7 +102,7 @@ class PostgresServer {
     if (_useV3) {
       return PostgreSQLConnection.withV3(
         e,
-        sessionSettings: SessionSettings(
+        connectionSettings: ConnectionSettings(
           sslMode: sslMode,
           replicationMode: replicationMode,
           allowSuperfluousParameters: true,

--- a/test/docker.dart
+++ b/test/docker.dart
@@ -82,7 +82,7 @@ class PostgresServer {
   }) async {
     return Connection.open(
       await endpoint(),
-      connectionSettings: ConnectionSettings(
+      settings: ConnectionSettings(
         connectTimeout: Duration(seconds: 3),
         queryTimeout: Duration(seconds: 3),
         replicationMode: replicationMode,

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -5,8 +5,6 @@ import 'package:test/test.dart';
 
 import 'docker.dart';
 
-final _connectionSettings = ConnectionSettings();
-
 void main() {
   withPostgresServer('generic', (server) {
     late Pool pool;
@@ -14,8 +12,7 @@ void main() {
     setUp(() async {
       pool = Pool.withEndpoints(
         [await server.endpoint()],
-        connectionSettings: _connectionSettings,
-        poolSettings: PoolSettings(maxConnectionCount: 8),
+        settings: PoolSettings(maxConnectionCount: 8),
       );
 
       // We can't write to the public schema by default in postgres 15, so
@@ -83,8 +80,7 @@ void main() {
     test('can limit concurrent connections', () async {
       final pool = Pool.withEndpoints(
         [await server.endpoint()],
-        connectionSettings: _connectionSettings,
-        poolSettings: const PoolSettings(maxConnectionCount: 2),
+        settings: PoolSettings(maxConnectionCount: 2),
       );
       addTearDown(pool.close);
 

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 import 'docker.dart';
 
-final _sessionSettings = SessionSettings();
+final _connectionSettings = ConnectionSettings();
 
 void main() {
   withPostgresServer('generic', (server) {
@@ -14,7 +14,7 @@ void main() {
     setUp(() async {
       pool = Pool.withEndpoints(
         [await server.endpoint()],
-        sessionSettings: _sessionSettings,
+        connectionSettings: _connectionSettings,
         poolSettings: PoolSettings(maxConnectionCount: 8),
       );
 
@@ -83,7 +83,7 @@ void main() {
     test('can limit concurrent connections', () async {
       final pool = Pool.withEndpoints(
         [await server.endpoint()],
-        sessionSettings: _sessionSettings,
+        connectionSettings: _connectionSettings,
         poolSettings: const PoolSettings(maxConnectionCount: 2),
       );
       addTearDown(pool.close);

--- a/test/transaction_test.dart
+++ b/test/transaction_test.dart
@@ -713,7 +713,7 @@ void main() {
       final c3 = Completer();
       final f1 = Future.microtask(
         () => conn1.runTx(
-          transactionMode: TransactionMode(
+          settings: TransactionSettings(
             isolationLevel: IsolationLevel.readCommitted,
           ),
           (session) async {
@@ -727,7 +727,7 @@ void main() {
       );
       final f2 = Future.microtask(
         () => conn2.runTx(
-          transactionMode: TransactionMode(
+          settings: TransactionSettings(
             isolationLevel: IsolationLevel.readCommitted,
           ),
           (session) async {
@@ -750,7 +750,7 @@ void main() {
       final c3 = Completer();
       final f1 = Future.microtask(
         () => conn1.runTx(
-          transactionMode: TransactionMode(
+          settings: TransactionSettings(
             isolationLevel: IsolationLevel.serializable,
           ),
           (session) async {
@@ -764,7 +764,7 @@ void main() {
       );
       final f2 = Future.microtask(
         () => conn2.runTx(
-          transactionMode: TransactionMode(
+          settings: TransactionSettings(
             isolationLevel: IsolationLevel.serializable,
           ),
           (session) async {

--- a/test/v3_close_test.dart
+++ b/test/v3_close_test.dart
@@ -11,7 +11,7 @@ void main() {
     setUp(() async {
       conn1 = await Connection.open(
         await server.endpoint(),
-        connectionSettings: ConnectionSettings(
+        settings: ConnectionSettings(
             //transformer: _loggingTransformer('c1'),
             ),
       );

--- a/test/v3_close_test.dart
+++ b/test/v3_close_test.dart
@@ -11,7 +11,7 @@ void main() {
     setUp(() async {
       conn1 = await Connection.open(
         await server.endpoint(),
-        sessionSettings: SessionSettings(
+        connectionSettings: ConnectionSettings(
             //transformer: _loggingTransformer('c1'),
             ),
       );

--- a/test/v3_logical_replication_test.dart
+++ b/test/v3_logical_replication_test.dart
@@ -68,7 +68,7 @@ void main() {
           password: 'replication',
           port: await server.port,
         ),
-        connectionSettings: ConnectionSettings(
+        settings: ConnectionSettings(
             replicationMode: ReplicationMode.logical,
             transformer: serverMessagesInterceptor.transformer,
             queryMode: QueryMode.simple),

--- a/test/v3_logical_replication_test.dart
+++ b/test/v3_logical_replication_test.dart
@@ -68,7 +68,7 @@ void main() {
           password: 'replication',
           port: await server.port,
         ),
-        sessionSettings: SessionSettings(
+        connectionSettings: ConnectionSettings(
             replicationMode: ReplicationMode.logical,
             transformer: serverMessagesInterceptor.transformer,
             queryMode: QueryMode.simple),

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 import 'docker.dart';
 
-final _sessionSettings = SessionSettings(
+final _connectionSettings = ConnectionSettings(
   transformer: loggingTransformer('conn'),
   applicationName: 'test_app',
 );
@@ -20,7 +20,7 @@ void main() {
     setUp(() async {
       connection = await Connection.open(
         await server.endpoint(),
-        sessionSettings: _sessionSettings,
+        connectionSettings: _connectionSettings,
       );
     });
 
@@ -428,7 +428,7 @@ void main() {
 
       final connection = await Connection.open(
         await server.endpoint(),
-        sessionSettings: SessionSettings(
+        connectionSettings: ConnectionSettings(
           transformer: transformer,
         ),
       );
@@ -447,14 +447,14 @@ void main() {
     setUp(() async {
       conn1 = await Connection.open(
         await server.endpoint(),
-        sessionSettings: SessionSettings(
+        connectionSettings: ConnectionSettings(
           transformer: loggingTransformer('c1'),
         ),
       );
 
       conn2 = await Connection.open(
         await server.endpoint(),
-        sessionSettings: SessionSettings(
+        connectionSettings: ConnectionSettings(
           transformer: loggingTransformer('c2'),
         ),
       );

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -227,8 +227,6 @@ void main() {
 
       await expectLater(
         connection.run(expectAsync1((session) async {
-          expect(identical(connection, session), isTrue);
-
           await session
               .execute('CREATE TEMPORARY TABLE foo (id INTEGER PRIMARY KEY);');
           await session.execute('INSERT INTO foo VALUES (3);');
@@ -242,6 +240,18 @@ void main() {
       expect(rows, [
         [3]
       ]);
+    });
+
+    test('run with bad query mode', () async {
+      await expectLater(
+          connection.run(settings: SessionSettings(queryMode: QueryMode.simple),
+              (session) async {
+            await session.execute(
+              r'SELECT * FROM foo WHERE where id = $1',
+              parameters: ['id#1'],
+            );
+          }),
+          throwsA(isA<PgException>()));
     });
 
     group('runTx', () {

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -20,7 +20,7 @@ void main() {
     setUp(() async {
       connection = await Connection.open(
         await server.endpoint(),
-        connectionSettings: _connectionSettings,
+        settings: _connectionSettings,
       );
     });
 
@@ -428,7 +428,7 @@ void main() {
 
       final connection = await Connection.open(
         await server.endpoint(),
-        connectionSettings: ConnectionSettings(
+        settings: ConnectionSettings(
           transformer: transformer,
         ),
       );
@@ -447,14 +447,14 @@ void main() {
     setUp(() async {
       conn1 = await Connection.open(
         await server.endpoint(),
-        connectionSettings: ConnectionSettings(
+        settings: ConnectionSettings(
           transformer: loggingTransformer('c1'),
         ),
       );
 
       conn2 = await Connection.open(
         await server.endpoint(),
-        connectionSettings: ConnectionSettings(
+        settings: ConnectionSettings(
           transformer: loggingTransformer('c2'),
         ),
       );


### PR DESCRIPTION
The separation is along the values where it may make sense to "temporary" override the defaults for a session vs. values that are fixed (or not likely to get override) for the life of a connection. `SessionSettings` could be passed into `run` and `runTx` to get such overrides.