### PR TITLE
Remove @internal annotation from ClientMessage methods.

### DIFF
--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -1,5 +1,6 @@
-library postgres.messages;
+library messages;
 
+export 'src/buffer.dart' show PgByteDataWriter;
 export 'src/client_messages.dart';
 export 'src/logical_replication_messages.dart';
 export 'src/server_messages.dart';

--- a/lib/src/client_messages.dart
+++ b/lib/src/client_messages.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:buffer/buffer.dart';
 import 'package:charcode/ascii.dart';
-import 'package:meta/meta.dart';
 
 import 'binary_codec.dart';
 import 'buffer.dart';
@@ -32,10 +31,8 @@ abstract class ClientMessageId {
 abstract class ClientMessage extends Message {
   const ClientMessage();
 
-  @internal
   void applyToBuffer(PgByteDataWriter buffer);
 
-  @internal
   Uint8List asBytes({required Encoding encoding}) {
     final buffer = PgByteDataWriter(encoding: encoding);
     applyToBuffer(buffer);


### PR DESCRIPTION
Also adding the buffer writer in the exported library.