### PR TITLE
Return explicit TypedBytes data class when the package is not able to decode the input bytes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,10 @@ Notable breaking behaviour changes:
   - Queries are not cached implicitly, explicit prepared statements can be
     used instead.
   - `interval` values are returned as `Interval` type instead of `Duration`.
-  - A newly added `Unknown` instances are returned when the package does not
-    know or has not implemented the appropriate type decoding yet. Previously
-    these values were auto-encoded to `String` and if that failed the raw
-    bytes were used. Now clients may decide, as `Unknown.asString` provides
-    easy access to String decoding too. 
+  - A newly added `TypedBytes` instances are returned when the package does
+    not know or has not implemented the appropriate type decoding yet.
+    Previously these values were auto-encoded to `String` and if that failed
+    the `Uint8List` were used.
   - Types, fields and parameter names may have been renamed to be more
     consistent or more aligned with the Dart naming guides.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Notable breaking behaviour changes:
   - Queries are not cached implicitly, explicit prepared statements can be
     used instead.
   - `interval` values are returned as `Interval` type instead of `Duration`.
+  - A newly added `Unknown` instances are returned when the package does not
+    know or has not implemented the appropriate type decoding yet. Previously
+    these values were auto-encoded to `String` and if that failed the raw
+    bytes were used. Now clients may decide, as `Unknown.asString` provides
+    easy access to String decoding too. 
   - Types, fields and parameter names may have been renamed to be more
     consistent or more aligned with the Dart naming guides.
 

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -53,12 +53,19 @@ class PostgresBinaryEncoder {
       return null;
     }
 
-    // ignore: unnecessary_cast
     switch (_type) {
       case Type.unknownType:
       case Type.unspecified:
+        {
+          // Pass-through of Uint8List instances allows client with custom types to
+          // encode their types for efficient binary transport.
+          if (input is Uint8List) {
+            return input;
+          }
+          throw ArgumentError('Cannot encode `$input` into ${_type.name}.');
+        }
       case Type.voidType:
-        throw ArgumentError('Cannot encode into ${_type.name}.');
+        throw ArgumentError('Cannot encode `$input` into ${_type.name}.');
       case Type.boolean:
         {
           if (input is bool) {

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -43,8 +43,8 @@ Codec<Object?, List<int>> _jsonFusedEncoding(Encoding encoding) {
   }
 }
 
-class PostgresBinaryEncoder<T extends Object> {
-  final Type<T> _type;
+class PostgresBinaryEncoder {
+  final Type _type;
 
   const PostgresBinaryEncoder(this._type);
 
@@ -54,7 +54,7 @@ class PostgresBinaryEncoder<T extends Object> {
     }
 
     // ignore: unnecessary_cast
-    switch (_type as Type<Object>) {
+    switch (_type) {
       case Type.unknownType:
       case Type.unspecified:
       case Type.voidType:
@@ -507,12 +507,12 @@ class PostgresBinaryEncoder<T extends Object> {
   }
 }
 
-class PostgresBinaryDecoder<T> {
+class PostgresBinaryDecoder {
   PostgresBinaryDecoder(this.type);
 
   final Type type;
 
-  T? convert(Uint8List? input, Encoding encoding) {
+  Object? convert(Uint8List? input, Encoding encoding) {
     if (input == null) {
       return null;
     }
@@ -524,52 +524,52 @@ class PostgresBinaryDecoder<T> {
       case Type.name:
       case Type.text:
       case Type.varChar:
-        return encoding.decode(input) as T;
+        return encoding.decode(input);
       case Type.boolean:
-        return (buffer.getInt8(0) != 0) as T;
+        return (buffer.getInt8(0) != 0);
       case Type.smallInteger:
-        return buffer.getInt16(0) as T;
+        return buffer.getInt16(0);
       case Type.serial:
       case Type.integer:
-        return buffer.getInt32(0) as T;
+        return buffer.getInt32(0);
       case Type.bigSerial:
       case Type.bigInteger:
-        return buffer.getInt64(0) as T;
+        return buffer.getInt64(0);
       case Type.real:
-        return buffer.getFloat32(0) as T;
+        return buffer.getFloat32(0);
       case Type.double:
-        return buffer.getFloat64(0) as T;
+        return buffer.getFloat64(0);
       case Type.timestampWithoutTimezone:
       case Type.timestampWithTimezone:
         return DateTime.utc(2000)
-            .add(Duration(microseconds: buffer.getInt64(0))) as T;
+            .add(Duration(microseconds: buffer.getInt64(0)));
 
       case Type.interval:
         return Interval(
           microseconds: buffer.getInt64(0),
           days: buffer.getInt32(8),
           months: buffer.getInt32(12),
-        ) as T;
+        );
 
       case Type.numeric:
-        return _decodeNumeric(input) as T;
+        return _decodeNumeric(input);
 
       case Type.date:
-        return DateTime.utc(2000).add(Duration(days: buffer.getInt32(0))) as T;
+        return DateTime.utc(2000).add(Duration(days: buffer.getInt32(0)));
 
       case Type.jsonb:
         {
           // Removes version which is first character and currently always '1'
           final bytes = input.buffer
               .asUint8List(input.offsetInBytes + 1, input.lengthInBytes - 1);
-          return _jsonFusedEncoding(encoding).decode(bytes) as T;
+          return _jsonFusedEncoding(encoding).decode(bytes);
         }
 
       case Type.json:
-        return _jsonFusedEncoding(encoding).decode(input) as T;
+        return _jsonFusedEncoding(encoding).decode(input);
 
       case Type.byteArray:
-        return input as T;
+        return input;
 
       case Type.uuid:
         {
@@ -588,59 +588,47 @@ class PostgresBinaryDecoder<T> {
             }
           }
 
-          return buf.toString() as T;
+          return buf.toString();
         }
       case Type.regtype:
         final data = input.buffer.asByteData(input.offsetInBytes, input.length);
         final oid = data.getInt32(0);
-        return (Type.byTypeOid[oid] ?? Type.unknownType) as T;
+        return Type.byTypeOid[oid] ?? Type.unknownType;
       case Type.voidType:
         return null;
 
       case Type.point:
-        return Point(buffer.getFloat64(0), buffer.getFloat64(8)) as T;
+        return Point(buffer.getFloat64(0), buffer.getFloat64(8));
 
       case Type.booleanArray:
         return readListBytes<bool>(
-            input, (reader, _) => reader.readUint8() != 0) as T;
+            input, (reader, _) => reader.readUint8() != 0);
 
       case Type.integerArray:
-        return readListBytes<int>(input, (reader, _) => reader.readInt32())
-            as T;
+        return readListBytes<int>(input, (reader, _) => reader.readInt32());
       case Type.bigIntegerArray:
-        return readListBytes<int>(input, (reader, _) => reader.readInt64())
-            as T;
+        return readListBytes<int>(input, (reader, _) => reader.readInt64());
 
       case Type.varCharArray:
       case Type.textArray:
         return readListBytes<String>(input, (reader, length) {
           return encoding.decode(length > 0 ? reader.read(length) : []);
-        }) as T;
+        });
 
       case Type.doubleArray:
-        return readListBytes<double>(input, (reader, _) => reader.readFloat64())
-            as T;
+        return readListBytes<double>(
+            input, (reader, _) => reader.readFloat64());
 
       case Type.jsonbArray:
         return readListBytes<dynamic>(input, (reader, length) {
           reader.read(1);
           final bytes = reader.read(length - 1);
           return _jsonFusedEncoding(encoding).decode(bytes);
-        }) as T;
+        });
 
       case Type.unknownType:
       case Type.unspecified:
-        {
-          // We'll try and decode this as a utf8 string and return that
-          // for many internal types, this is valid. If it fails,
-          // we just return the bytes and let the caller figure out what to
-          // do with it.
-          try {
-            return encoding.decode(input) as T;
-          } catch (_) {
-            return input as T;
-          }
-        }
+        return Unknown(bytes: input, encoding: encoding);
     }
   }
 

--- a/lib/src/binary_codec.dart
+++ b/lib/src/binary_codec.dart
@@ -515,9 +515,10 @@ class PostgresBinaryEncoder {
 }
 
 class PostgresBinaryDecoder {
-  PostgresBinaryDecoder(this.type);
-
+  final int typeOid;
   final Type type;
+
+  PostgresBinaryDecoder(this.typeOid, this.type);
 
   Object? convert(Uint8List? input, Encoding encoding) {
     if (input == null) {
@@ -635,7 +636,7 @@ class PostgresBinaryDecoder {
 
       case Type.unknownType:
       case Type.unspecified:
-        return Unknown(bytes: input, encoding: encoding);
+        return TypedBytes(typeOid: typeOid, bytes: input);
     }
   }
 

--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -4,10 +4,9 @@ import 'dart:typed_data';
 import 'exceptions.dart';
 import 'types.dart';
 
-class PostgresTextEncoder extends Converter<Object, String> {
+class PostgresTextEncoder {
   const PostgresTextEncoder();
 
-  @override
   String convert(dynamic input, {bool escapeStrings = true}) {
     if (input == null) {
       return 'null';

--- a/lib/src/text_codec.dart
+++ b/lib/src/text_codec.dart
@@ -217,9 +217,10 @@ class PostgresTextEncoder {
 }
 
 class PostgresTextDecoder {
+  final int _typeOid;
   final Type _type;
 
-  const PostgresTextDecoder(this._type);
+  const PostgresTextDecoder(this._typeOid, this._type);
 
   Object? convert(Uint8List? input, Encoding encoding) {
     if (input == null) return null;
@@ -272,10 +273,10 @@ class PostgresTextDecoder {
       case Type.jsonbArray:
       case Type.regtype:
         // TODO: implement proper decoding of the above
-        return Unknown(bytes: input, encoding: encoding);
+        return TypedBytes(typeOid: _typeOid, bytes: input);
       case Type.unspecified:
       case Type.unknownType:
-        return Unknown(bytes: input, encoding: encoding);
+        return TypedBytes(typeOid: _typeOid, bytes: input);
     }
   }
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -55,21 +55,23 @@ class Interval {
 @immutable
 class Unknown {
   final Uint8List bytes;
-  final Encoding encoding;
+  final Encoding _encoding;
 
   Unknown({
     required this.bytes,
-    required this.encoding,
-  });
+    required Encoding encoding,
+  }) : _encoding = encoding;
 
+  /// Returns the [bytes] decoded as [String] using the connection's encoding.
+  ///
+  /// Returns `null` when the bytes cannot be decoded as valid [String].
   late final asString = () {
     try {
-      return encoding.decode(bytes);
+      return _encoding.decode(bytes);
     } catch (_) {
       return null;
     }
   }();
-  late final isString = asString != null;
 }
 
 /// LSN is a PostgreSQL Log Sequence Number.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:core';
 import 'dart:core' as core;
 import 'dart:typed_data';
@@ -51,27 +50,16 @@ class Interval {
   }
 }
 
-/// Describes a returned value that the package was unable to decode.
+/// Describes a generic bytes string value..
 @immutable
-class Unknown {
+class TypedBytes {
+  final int typeOid;
   final Uint8List bytes;
-  final Encoding _encoding;
 
-  Unknown({
+  TypedBytes({
+    required this.typeOid,
     required this.bytes,
-    required Encoding encoding,
-  }) : _encoding = encoding;
-
-  /// Returns the [bytes] decoded as [String] using the connection's encoding.
-  ///
-  /// Returns `null` when the bytes cannot be decoded as valid [String].
-  late final asString = () {
-    try {
-      return _encoding.decode(bytes);
-    } catch (_) {
-      return null;
-    }
-  }();
+  });
 }
 
 /// LSN is a PostgreSQL Log Sequence Number.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:core';
 import 'dart:core' as core;
+import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 
@@ -47,6 +49,27 @@ class Interval {
         other.days == days &&
         other.microseconds == microseconds;
   }
+}
+
+/// Describes a returned value that the package was unable to decode.
+@immutable
+class Unknown {
+  final Uint8List bytes;
+  final Encoding encoding;
+
+  Unknown({
+    required this.bytes,
+    required this.encoding,
+  });
+
+  late final asString = () {
+    try {
+      return encoding.decode(bytes);
+    } catch (_) {
+      return null;
+    }
+  }();
+  late final isString = asString != null;
 }
 
 /// LSN is a PostgreSQL Log Sequence Number.

--- a/lib/src/v2/query.dart
+++ b/lib/src/v2/query.dart
@@ -171,7 +171,9 @@ class Query<T> {
     final lazyDecodedData = rawRowData.map((bd) {
       iterator.moveNext();
       final converter = PostgresBinaryDecoder(
-          Type.byTypeOid[iterator.current.typeOid] ?? Type.unknownType);
+        iterator.current.typeOid,
+        Type.byTypeOid[iterator.current.typeOid] ?? Type.unknownType,
+      );
       return converter.convert(bd, connection.encoding);
     });
 

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -678,10 +678,10 @@ class _PgResultStreamSubscription
             final type = field.type;
             late final dynamic value;
             if (field.isBinaryEncoding) {
-              value = PostgresBinaryDecoder(type)
+              value = PostgresBinaryDecoder(field.typeOid, type)
                   .convert(message.values[i], session.encoding);
             } else {
-              value = PostgresTextDecoder(type)
+              value = PostgresTextDecoder(field.typeOid, type)
                   .convert(message.values[i], session.encoding);
             }
 

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -250,7 +250,7 @@ void main() {
         '0.0': [0, 0, 0, 0, 0, 0, 0, 1], // .0 or 0.0
       };
 
-      final decoder = PostgresBinaryDecoder(Type.numeric);
+      final decoder = PostgresBinaryDecoder(Type.numeric.oid!, Type.numeric);
       binaries.forEach((key, value) {
         final uint8List = Uint8List.fromList(value);
         final res = decoder.convert(uint8List, utf8);

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -667,7 +667,7 @@ Future expectInverse(dynamic value, Type dataType) async {
     dataType = Type.bigInteger;
   }
 
-  final decoder = PostgresBinaryDecoder(dataType);
+  final decoder = PostgresBinaryDecoder(dataType.oid!, dataType);
   final decodedValue = decoder.convert(encodedValue, utf8);
 
   expect(decodedValue, value);

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -243,7 +243,7 @@ void main() {
         '0.0': [0, 0, 0, 0, 0, 0, 0, 1], // .0 or 0.0
       };
 
-      final encoder = PostgresBinaryEncoder<Object>(Type.numeric);
+      final encoder = PostgresBinaryEncoder(Type.numeric);
       binaries.forEach((key, value) {
         final uint8List = Uint8List.fromList(value);
         final res = encoder.convert(key, utf8);
@@ -618,7 +618,7 @@ void main() {
   });
 
   test('Invalid UUID encoding', () {
-    final converter = PostgresBinaryEncoder<Object>(Type.uuid);
+    final converter = PostgresBinaryEncoder(Type.uuid);
     try {
       converter.convert('z0000000-0000-0000-0000-000000000000', utf8);
       fail('unreachable');


### PR DESCRIPTION
Also:
- explicit list of the types not handled yet in text decoder
- removed unusable type cast in both the binary and the text decoder