### PR TITLE
Desugar positional variables

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -32,7 +32,8 @@ export 'src/types.dart';
 /// Alternatively, you can use named variables that will be desugared by this
 /// package with the [Sql.named] factory. If you prefer positional variables,
 /// but want to specify their types in text or use a different symbol for
-/// variables (Postgres uses `$`), you
+/// variables (Postgres uses `$`), you can use the [Sql.indexed] constructor
+/// instead.
 class Sql {
   /// The default constructor, sending [sql] to the Postgres database without
   /// any modification.
@@ -48,7 +49,8 @@ class Sql {
   /// This mode is very similar to the native format understood by postgres,
   /// except that:
   ///  1. The character for variables is customizable (postgres will always use
-  ///     `@`). This method also uses `@` by default, but this can be changed.
+  ///     `$`). To be consistent with [Sql.named], this method uses `@` as the
+  ///     default character.
   ///  2. Not every variable needs to have en explicit index. When declaring a
   ///     variable without an index, the first index higher than any previously
   ///     seen index is used instead.

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -30,7 +30,9 @@ export 'src/types.dart';
 /// [Statement.run].
 ///
 /// Alternatively, you can use named variables that will be desugared by this
-/// package with the [Sql.named] factory.
+/// package with the [Sql.named] factory. If you prefer positional variables,
+/// but want to specify their types in text or use a different symbol for
+/// variables (Postgres uses `$`), you
 class Sql {
   /// The default constructor, sending [sql] to the Postgres database without
   /// any modification.
@@ -40,6 +42,24 @@ class Sql {
   /// instances can be used when binding values later.
   factory Sql(String sql, {List<Type>? types}) =
       InternalQueryDescription.direct;
+
+  /// Looks for positional parameters in [sql] and desugars them.
+  ///
+  /// This mode is very similar to the native format understood by postgres,
+  /// except that:
+  ///  1. The character for variables is customizable (postgres will always use
+  ///     `@`). This method also uses `@` by default, but this can be changed.
+  ///  2. Not every variable needs to have en explicit index. When declaring a
+  ///     variable without an index, the first index higher than any previously
+  ///     seen index is used instead.
+  ///
+  /// For instance, `Sql.indexed('SELECT ?2, ?, ?1', substitution: '?')`
+  /// declares three variables (appearing in the order 2, 3, 1).
+  ///
+  /// Just like with [Sql.named], it is possible to declare an explicit type for
+  /// variables: `Sql.indexed('SELECT @1:int8')`.
+  factory Sql.indexed(String sql, {String substitution}) =
+      InternalQueryDescription.indexed;
 
   /// Looks for named parameters in [sql] and desugars them.
   ///

--- a/lib/src/v3/query_description.dart
+++ b/lib/src/v3/query_description.dart
@@ -28,7 +28,7 @@ class InternalQueryDescription implements Sql {
     String original,
     String transformed,
     List<Type?> parameterTypes,
-    Map<String, int> namedVariables,
+    Map<String, int>? namedVariables,
   ) : this._(
           transformed,
           original,
@@ -36,8 +36,18 @@ class InternalQueryDescription implements Sql {
           namedVariables,
         );
 
+  factory InternalQueryDescription.indexed(String sql,
+      {String substitution = '@'}) {
+    return _viaTokenizer(sql, substitution, TokenizerMode.indexed);
+  }
+
   factory InternalQueryDescription.named(String sql,
       {String substitution = '@'}) {
+    return _viaTokenizer(sql, substitution, TokenizerMode.named);
+  }
+
+  static InternalQueryDescription _viaTokenizer(
+      String sql, String substitution, TokenizerMode mode) {
     final charCodes = substitution.codeUnits;
     if (charCodes.length != 1) {
       throw ArgumentError.value(substitution, 'substitution',
@@ -45,7 +55,8 @@ class InternalQueryDescription implements Sql {
     }
 
     final tokenizer =
-        VariableTokenizer(variableCodeUnit: charCodes[0], sql: sql)..tokenize();
+        VariableTokenizer(variableCodeUnit: charCodes[0], sql: sql, mode: mode)
+          ..tokenize();
 
     return tokenizer.result;
   }


### PR DESCRIPTION
In addition to `Sql.named`, this adds `Sql.indexed` where variables are given numbers instead of names.

This should close https://github.com/isoos/postgresql-dart/issues/93 (cc @insinfo, could you take a look if this is what you had in mind?).