### PR TITLE
DecodeInput.typeRegistry

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -328,11 +328,13 @@ class DecodeInput {
   final Uint8List bytes;
   final bool isBinary;
   final Encoding encoding;
+  final TypeRegistry typeRegistry;
 
   DecodeInput({
     required this.bytes,
     required this.isBinary,
     required this.encoding,
+    required this.typeRegistry,
   });
 
   late final asText = encoding.decode(bytes);

--- a/lib/src/types/binary_codec.dart
+++ b/lib/src/types/binary_codec.dart
@@ -510,7 +510,9 @@ class PostgresBinaryDecoder {
 
   PostgresBinaryDecoder(this.typeOid);
 
-  Object? convert(Uint8List input, Encoding encoding) {
+  Object? convert(DecodeInput dinput) {
+    final encoding = dinput.encoding;
+    final input = dinput.bytes;
     late final buffer =
         ByteData.view(input.buffer, input.offsetInBytes, input.lengthInBytes);
 
@@ -585,8 +587,7 @@ class PostgresBinaryDecoder {
       case TypeOid.regtype:
         final data = input.buffer.asByteData(input.offsetInBytes, input.length);
         final oid = data.getInt32(0);
-        // TODO: DecodeInput may provide the connection-level TypeRegistry
-        return TypeRegistry().resolveOid(oid);
+        return dinput.typeRegistry.resolveOid(oid);
       case TypeOid.voidType:
         return null;
 

--- a/lib/src/types/generic_type.dart
+++ b/lib/src/types/generic_type.dart
@@ -48,8 +48,7 @@ class GenericType<T extends Object> extends Type<T> {
   @override
   T? decode(DecodeInput input) {
     if (input.isBinary) {
-      return PostgresBinaryDecoder(oid!).convert(input.bytes, input.encoding)
-          as T?;
+      return PostgresBinaryDecoder(oid!).convert(input) as T?;
     } else {
       return PostgresTextDecoder(oid!).convert(input) as T?;
     }

--- a/lib/src/v2/query.dart
+++ b/lib/src/v2/query.dart
@@ -174,7 +174,12 @@ class Query<T> {
       if (bd == null) {
         return null;
       }
-      return converter.convert(bd, connection.encoding);
+      return converter.convert(DecodeInput(
+        bytes: bd,
+        isBinary: true,
+        encoding: connection.encoding,
+        typeRegistry: TypeRegistry(),
+      ));
     });
 
     rows.add(lazyDecodedData.toList());

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -682,6 +682,7 @@ class _PgResultStreamSubscription
                     bytes: input,
                     isBinary: field.isBinaryEncoding,
                     encoding: session.encoding,
+                    typeRegistry: session._connection._settings.typeRegistry,
                   ));
             columnValues.add(value);
           }

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
+import 'package:buffer/buffer.dart';
 import 'package:postgres/legacy.dart';
 import 'package:postgres/postgres.dart';
 import 'package:postgres/src/types/binary_codec.dart';
+import 'package:postgres/src/types/type_registry.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';
@@ -252,8 +253,13 @@ void main() {
 
       final decoder = PostgresBinaryDecoder(Type.numeric.oid!);
       binaries.forEach((key, value) {
-        final uint8List = Uint8List.fromList(value);
-        final res = decoder.convert(uint8List, utf8);
+        final input = DecodeInput(
+          bytes: castBytes(value),
+          isBinary: true,
+          encoding: utf8,
+          typeRegistry: TypeRegistry(),
+        );
+        final res = decoder.convert(input);
         expect(res, key);
       });
     });

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -6,6 +6,7 @@ import 'package:postgres/legacy.dart';
 import 'package:postgres/postgres.dart';
 import 'package:postgres/src/types/binary_codec.dart';
 import 'package:postgres/src/types/text_codec.dart';
+import 'package:postgres/src/types/type_registry.dart';
 import 'package:test/test.dart';
 
 import 'docker.dart';
@@ -668,7 +669,12 @@ Future expectInverse(dynamic value, Type dataType) async {
   final encodedValue = encoder.convert(value, utf8);
 
   final decoder = PostgresBinaryDecoder(dataType.oid!);
-  final decodedValue = decoder.convert(encodedValue, utf8);
+  final decodedValue = decoder.convert(DecodeInput(
+    bytes: encodedValue,
+    isBinary: true,
+    encoding: utf8,
+    typeRegistry: TypeRegistry(),
+  ));
 
   expect(decodedValue, value);
 }


### PR DESCRIPTION
This is also important for the use case where we have separate type classes.