### PR TITLE
Make builtin types const again

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -138,141 +138,139 @@ class Point {
 /// Supported data types.
 abstract class Type<T extends Object> {
   /// Used to represent value without any type representation.
-  static final unspecified = unspecifiedType();
+  static const unspecified = UnspecifiedType();
 
   /// Must be a [String].
-  static final text =
-      _genericType<String>(TypeOid.text, nameForSubstitution: 'text');
+  static const text =
+      GenericType<String>(TypeOid.text, nameForSubstitution: 'text');
 
   /// Must be an [int] (4-byte integer)
-  static final integer =
-      _genericType<int>(TypeOid.integer, nameForSubstitution: 'int4');
+  static const integer =
+      GenericType<int>(TypeOid.integer, nameForSubstitution: 'int4');
 
   /// Must be an [int] (2-byte integer)
-  static final smallInteger =
-      _genericType<int>(TypeOid.smallInteger, nameForSubstitution: 'int2');
+  static const smallInteger =
+      GenericType<int>(TypeOid.smallInteger, nameForSubstitution: 'int2');
 
   /// Must be an [int] (8-byte integer)
-  static final bigInteger =
-      _genericType<int>(TypeOid.bigInteger, nameForSubstitution: 'int8');
+  static const bigInteger =
+      GenericType<int>(TypeOid.bigInteger, nameForSubstitution: 'int8');
 
   /// Must be an [int] (autoincrementing 4-byte integer)
-  static final serial = _genericType<int>(null, nameForSubstitution: 'int4');
+  static const serial = GenericType<int>(null, nameForSubstitution: 'int4');
 
   /// Must be an [int] (autoincrementing 8-byte integer)
-  static final bigSerial = _genericType<int>(null, nameForSubstitution: 'int8');
+  static const bigSerial = GenericType<int>(null, nameForSubstitution: 'int8');
 
   /// Must be a [double] (32-bit floating point value)
-  static final real =
-      _genericType<core.double>(TypeOid.real, nameForSubstitution: 'float4');
+  static const real =
+      GenericType<core.double>(TypeOid.real, nameForSubstitution: 'float4');
 
   /// Must be a [double] (64-bit floating point value)
-  static final double =
-      _genericType<core.double>(TypeOid.double, nameForSubstitution: 'float8');
+  static const double =
+      GenericType<core.double>(TypeOid.double, nameForSubstitution: 'float8');
 
   /// Must be a [bool]
-  static final boolean =
-      _genericType<bool>(TypeOid.boolean, nameForSubstitution: 'boolean');
+  static const boolean =
+      GenericType<bool>(TypeOid.boolean, nameForSubstitution: 'boolean');
 
   /// Must be a [DateTime] (microsecond date and time precision)
-  static final timestampWithoutTimezone = _genericType<DateTime>(
+  static const timestampWithoutTimezone = GenericType<DateTime>(
       TypeOid.timestampWithoutTimezone,
       nameForSubstitution: 'timestamp');
 
   /// Must be a [DateTime] (microsecond date and time precision)
-  static final timestampWithTimezone = _genericType<DateTime>(
+  static const timestampWithTimezone = GenericType<DateTime>(
       TypeOid.timestampWithTimezone,
       nameForSubstitution: 'timestamptz');
 
   /// Must be a [Interval]
-  static final interval =
-      _genericType<Interval>(TypeOid.interval, nameForSubstitution: 'interval');
+  static const interval =
+      GenericType<Interval>(TypeOid.interval, nameForSubstitution: 'interval');
 
   /// An arbitrary-precision number.
   ///
   /// This library supports encoding numbers in a textual format, or when
   /// passed as [int] or [double]. When decoding values, numeric types are
   /// always returned as string.
-  static final numeric =
-      _genericType<Object>(TypeOid.numeric, nameForSubstitution: 'numeric');
+  static const numeric =
+      GenericType<Object>(TypeOid.numeric, nameForSubstitution: 'numeric');
 
   /// Must be a [DateTime] (contains year, month and day only)
-  static final date =
-      _genericType<DateTime>(TypeOid.date, nameForSubstitution: 'date');
+  static const date =
+      GenericType<DateTime>(TypeOid.date, nameForSubstitution: 'date');
 
   /// Must be encodable via [json.encode].
   ///
   /// Values will be encoded via [json.encode] before being sent to the database.
-  static final jsonb = GenericType(TypeOid.jsonb, nameForSubstitution: 'jsonb');
+  static const jsonb = GenericType(TypeOid.jsonb, nameForSubstitution: 'jsonb');
 
   /// Must be encodable via [core.json.encode].
   ///
   /// Values will be encoded via [core.json.encode] before being sent to the database.
-  static final json = GenericType(TypeOid.json, nameForSubstitution: 'json');
+  static const json = GenericType(TypeOid.json, nameForSubstitution: 'json');
 
   /// Must be a [List] of [int].
   ///
   /// Each element of the list must fit into a byte (0-255).
-  static final byteArray =
-      _genericType<List<int>>(TypeOid.byteArray, nameForSubstitution: 'bytea');
+  static const byteArray =
+      GenericType<List<int>>(TypeOid.byteArray, nameForSubstitution: 'bytea');
 
   /// Must be a [String]
   ///
   /// Used for internal pg structure names
-  static final name =
-      _genericType<String>(TypeOid.name, nameForSubstitution: 'name');
+  static const name =
+      GenericType<String>(TypeOid.name, nameForSubstitution: 'name');
 
   /// Must be a [String].
   ///
   /// Must contain 32 hexadecimal characters. May contain any number of '-' characters.
   /// When returned from database, format will be xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
-  static final uuid =
-      _genericType<String>(TypeOid.uuid, nameForSubstitution: 'uuid');
+  static const uuid =
+      GenericType<String>(TypeOid.uuid, nameForSubstitution: 'uuid');
 
   /// Must be a [Point]
-  static final point =
-      _genericType<Point>(TypeOid.point, nameForSubstitution: 'point');
+  static const point =
+      GenericType<Point>(TypeOid.point, nameForSubstitution: 'point');
 
   /// Must be a [List<bool>]
-  static final booleanArray = _genericType<List<bool>>(TypeOid.booleanArray,
+  static const booleanArray = GenericType<List<bool>>(TypeOid.booleanArray,
       nameForSubstitution: '_bool');
 
   /// Must be a [List<int>]
-  static final integerArray = _genericType<List<int>>(TypeOid.integerArray,
+  static const integerArray = GenericType<List<int>>(TypeOid.integerArray,
       nameForSubstitution: '_int4');
 
   /// Must be a [List<int>]
-  static final bigIntegerArray = _genericType<List<int>>(
-      TypeOid.bigIntegerArray,
+  static const bigIntegerArray = GenericType<List<int>>(TypeOid.bigIntegerArray,
       nameForSubstitution: '_int8');
 
   /// Must be a [List<String>]
-  static final textArray = _genericType<List<String>>(TypeOid.textArray,
+  static const textArray = GenericType<List<String>>(TypeOid.textArray,
       nameForSubstitution: '_text');
 
   /// Must be a [List<double>]
-  static final doubleArray = _genericType<List<core.double>>(
-      TypeOid.doubleArray,
+  static const doubleArray = GenericType<List<core.double>>(TypeOid.doubleArray,
       nameForSubstitution: '_float8');
 
   /// Must be a [String]
-  static final varChar =
-      _genericType<String>(TypeOid.varChar, nameForSubstitution: 'varchar');
+  static const varChar =
+      GenericType<String>(TypeOid.varChar, nameForSubstitution: 'varchar');
 
   /// Must be a [List<String>]
-  static final varCharArray = _genericType<List<String>>(TypeOid.varCharArray,
+  static const varCharArray = GenericType<List<String>>(TypeOid.varCharArray,
       nameForSubstitution: '_varchar');
 
   /// Must be a [List] of encodable objects
-  static final jsonbArray =
-      _genericType<List>(TypeOid.jsonbArray, nameForSubstitution: '_jsonb');
+  static const jsonbArray =
+      GenericType<List>(TypeOid.jsonbArray, nameForSubstitution: '_jsonb');
 
   /// Must be a [Type].
-  static final regtype =
-      _genericType<Type>(TypeOid.regtype, nameForSubstitution: 'regtype');
+  static const regtype =
+      GenericType<Type>(TypeOid.regtype, nameForSubstitution: 'regtype');
 
   /// Impossible to bind to, always null when read.
-  static final voidType = _genericType<Object>(TypeOid.voidType);
+  static const voidType = GenericType<Object>(TypeOid.voidType);
 
   /// The object ID of this data type.
   final int? oid;
@@ -284,10 +282,6 @@ abstract class Type<T extends Object> {
   @override
   String toString() => 'Type(oid:$oid)';
 }
-
-Type<T> _genericType<T extends Object>(int? typeOid,
-        {String? nameForSubstitution}) =>
-    GenericType<T>(typeOid, nameForSubstitution: nameForSubstitution);
 
 class TypedValue<T extends Object> {
   final Type<T> type;

--- a/lib/src/types/type_registry.dart
+++ b/lib/src/types/type_registry.dart
@@ -44,7 +44,7 @@ class TypeOid {
   static const voidType = 2278;
 }
 
-final _builtInTypes = <Type>{
+const _builtInTypes = <Type>{
   Type.unspecified,
   Type.name,
   Type.text,


### PR DESCRIPTION
I'm currently relying on types being constant in `drift_postgres`, and it seems like there is no clear reason for them not be constants. So if that change wasn't intentional, this PR makes them constants again.