### PR TITLE
Rename TypedBytes -> UndecodedBytes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Notable breaking behaviour changes:
   - Queries are not cached implicitly, explicit prepared statements can be
     used instead.
   - `interval` values are returned as `Interval` type instead of `Duration`.
-  - A newly added `TypedBytes` instances are returned when the package does
+  - A newly added `UndecodedBytes` instances are returned when the package does
     not know or has not implemented the appropriate type decoding yet.
     Previously these values were auto-encoded to `String` and if that failed
     the `Uint8List` were used.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:core';
 import 'dart:core' as core;
 import 'dart:typed_data';
@@ -53,14 +54,20 @@ class Interval {
 
 /// Describes a generic bytes string value..
 @immutable
-class TypedBytes {
+class UndecodedBytes {
   final int typeOid;
+  final bool isBinary;
   final Uint8List bytes;
+  final Encoding encoding;
 
-  TypedBytes({
+  UndecodedBytes({
     required this.typeOid,
+    required this.isBinary,
     required this.bytes,
+    required this.encoding,
   });
+
+  late final asString = encoding.decode(bytes);
 }
 
 /// LSN is a PostgreSQL Log Sequence Number.

--- a/lib/src/types/binary_codec.dart
+++ b/lib/src/types/binary_codec.dart
@@ -621,7 +621,12 @@ class PostgresBinaryDecoder {
           return _jsonFusedEncoding(encoding).decode(bytes);
         });
     }
-    return TypedBytes(typeOid: typeOid, bytes: input);
+    return UndecodedBytes(
+      typeOid: typeOid,
+      bytes: input,
+      isBinary: true,
+      encoding: encoding,
+    );
   }
 
   List<V> readListBytes<V>(Uint8List data,

--- a/lib/src/types/text_codec.dart
+++ b/lib/src/types/text_codec.dart
@@ -270,8 +270,18 @@ class PostgresTextDecoder {
       case TypeOid.jsonbArray:
       case TypeOid.regtype:
         // TODO: implement proper decoding of the above
-        return TypedBytes(typeOid: _typeOid, bytes: di.bytes);
+        return UndecodedBytes(
+          typeOid: _typeOid,
+          bytes: di.bytes,
+          isBinary: false,
+          encoding: di.encoding,
+        );
     }
-    return TypedBytes(typeOid: _typeOid, bytes: di.bytes);
+    return UndecodedBytes(
+      typeOid: _typeOid,
+      bytes: di.bytes,
+      isBinary: false,
+      encoding: di.encoding,
+    );
   }
 }

--- a/lib/src/types/type_registry.dart
+++ b/lib/src/types/type_registry.dart
@@ -157,8 +157,18 @@ extension TypeRegistryExt on TypeRegistry {
           typeRegistry: this,
         ));
       case UnknownType():
-        return TypedBytes(typeOid: typeOid, bytes: bytes);
+        return UndecodedBytes(
+          typeOid: typeOid,
+          bytes: bytes,
+          isBinary: isBinary,
+          encoding: encoding,
+        );
     }
-    return TypedBytes(typeOid: typeOid, bytes: bytes);
+    return UndecodedBytes(
+      typeOid: typeOid,
+      bytes: bytes,
+      isBinary: isBinary,
+      encoding: encoding,
+    );
   }
 }


### PR DESCRIPTION
Originally I thought that `TypedBytes` may be useful for other use cases, but I don't see it happen, and the extra format + the encoding info is also useful if somebody needs to process it.