### PR TITLE
Dispose closed pool connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.2
+
+- Fix: Dispose disconnected pool `Connection`s.
+
 ## 3.0.1
 
 - Fix: do not allow `execute` after closing the `Connection`.
@@ -125,7 +129,7 @@ who helped to push forward.
   - Add LSN type and time conversion to and from ms-since-Y2K. [#53](https://github.com/isoos/postgresql-dart/pull/53) by [osaxma](https://github.com/osaxma)
   - Fix affected rows parsing in CommandCompleteMessage. [#52](https://github.com/isoos/postgresql-dart/pull/52) by [osaxma](https://github.com/osaxma)
   - Introduced new APIs to `PostgreSQLConnection`: `addMessage` to send client messages, `messages` stream to listen to server messages & `useSimpleQueryProtocol` option in `query` method. [#51](https://github.com/isoos/postgresql-dart/pull/51) by [osaxma](https://github.com/osaxma)
-  
+
 ## 2.4.6
 
 - Fix crash when manually issuing a transaction statement like `BEGIN` without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.2
 
-- Fix: Dispose disconnected pool `Connection`s.
+- Fix: Dispose disconnected pool `Connection`s. ([#260](https://github.com/isoos/postgresql-dart/pull/260) by [nehzata](https://github.com/nehzata)).
 
 ## 3.0.1
 

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -158,16 +158,18 @@ class PoolImplementation<L> implements Pool<L> {
     } finally {
       resource.release();
       sw.stop();
-      connection?._elapsedInUse += sw.elapsed;
 
       // If the pool has been closed, this connection needs to be closed as
       // well.
-      if (_semaphore.isClosed || !reuse) {
-        await connection?._dispose();
-      } else {
-        // Allow the connection to be re-used later.
-        connection?._isInUse = false;
-        connection?._lastReturned = DateTime.now();
+      if (connection != null) {
+        connection._elapsedInUse += sw.elapsed;
+        if (_semaphore.isClosed || !reuse || !connection.isOpen) {
+          await connection._dispose();
+        } else {
+          // Allow the connection to be re-used later.
+          connection._isInUse = false;
+          connection._lastReturned = DateTime.now();
+        }
       }
     }
   }

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -135,6 +135,7 @@ void main() {
         ),
       );
 
+      await conn.execute('-- test'); // this doesn't throw but it causes the connection to close
       await db.execute('SELECT 1');
     });
   });

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -135,7 +135,7 @@ void main() {
         ),
       );
 
-      await conn.execute('-- test'); // this doesn't throw but it causes the connection to close
+      await db.execute('-- test'); // this doesn't throw but it causes the connection to close
       await db.execute('SELECT 1');
     });
   });

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -126,6 +126,17 @@ void main() {
 
       await db.execute('SELECT 1');
     });
+
+    test('empty query does not lock up pool instance', () async {
+      final db = Pool.withEndpoints(
+        [await server.endpoint()],
+        settings: PoolSettings(
+          maxConnectionCount: 1,
+        ),
+      );
+
+      await db.execute('SELECT 1');
+    });
   });
 
   withPostgresServer('limit pool connections', (server) {


### PR DESCRIPTION
In some cases the connection gets closed after a query is executed without throwing an error. This patch checks to see if the connection has been closed and disposes of it.

steps to replicate:

```dart
final conn = Pool.withEndpoints(....);
await conn.execute('-- test'); // this doesn't throw but it causes the connection to close
await conn.execute('select true'); // this throws because the pool picks up the previously closed connection. a PgException(Severity.error Connection is closing down) error is thrown. 
```