### PR TITLE
rename Type.char -> character

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -148,7 +148,7 @@ abstract class Type<T extends Object> {
   static const unspecified = UnspecifiedType();
 
   /// Must be a [String]
-  static const char = GenericType<String>(TypeOid.char);
+  static const character = GenericType<String>(TypeOid.character);
 
   /// Must be a [String].
   static const text = GenericType<String>(TypeOid.text);

--- a/lib/src/types/binary_codec.dart
+++ b/lib/src/types/binary_codec.dart
@@ -92,7 +92,7 @@ class PostgresBinaryEncoder {
           throw FormatException(
               'Invalid type for parameter value. Expected: int Got: ${input.runtimeType}');
         }
-      case TypeOid.char:
+      case TypeOid.character:
       case TypeOid.name:
       case TypeOid.text:
       case TypeOid.varChar:
@@ -519,7 +519,7 @@ class PostgresBinaryDecoder {
         ByteData.view(input.buffer, input.offsetInBytes, input.lengthInBytes);
 
     switch (typeOid) {
-      case TypeOid.char:
+      case TypeOid.character:
       case TypeOid.name:
       case TypeOid.text:
       case TypeOid.varChar:

--- a/lib/src/types/text_codec.dart
+++ b/lib/src/types/text_codec.dart
@@ -228,7 +228,7 @@ class PostgresTextDecoder {
   Object? convert(DecodeInput di) {
     // ignore: unnecessary_cast
     switch (_typeOid) {
-      case TypeOid.char:
+      case TypeOid.character:
       case TypeOid.name:
       case TypeOid.text:
       case TypeOid.varChar:

--- a/lib/src/types/type_registry.dart
+++ b/lib/src/types/type_registry.dart
@@ -20,7 +20,7 @@ class TypeOid {
   static const boolean = 16;
   static const booleanArray = 1000;
   static const byteArray = 17;
-  static const char = 1042;
+  static const character = 1042;
   static const date = 1082;
   static const double = 701;
   static const doubleArray = 1022;
@@ -48,7 +48,7 @@ class TypeOid {
 
 final _builtInTypes = <Type>{
   Type.unspecified,
-  Type.char,
+  Type.character,
   Type.name,
   Type.text,
   Type.varChar,
@@ -83,9 +83,9 @@ final _builtInTypeNames = <String, Type>{
   'bigint': Type.bigInteger,
   'boolean': Type.boolean,
   'bytea': Type.byteArray,
-  'bpchar': Type.char,
-  'char': Type.char,
-  'character': Type.char,
+  'bpchar': Type.character,
+  'char': Type.character,
+  'character': Type.character,
   'date': Type.date,
   'double precision': Type.double,
   'float4': Type.real,

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -314,7 +314,6 @@ void main() {
       );
     });
 
-
     test('varchar', () async {
       await expectReversible(
         'varchar',


### PR DESCRIPTION
As apparently `char` (without any size in parenthesis) is a special data type in postgres that is not intended for external use.