### PR TITLE
Add security context parameter to endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.6
+
+- Allow passing a `SecurityContext` when opening postgres connections.
+
 ## 3.0.5
 
 - Support for type `char`/`character`/`bpchar`.

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -365,14 +365,6 @@ final class Endpoint {
   final String? password;
   final bool isUnixSocket;
 
-  /// The [SecurityContext] to use when connecting to this endpoint.
-  ///
-  /// This can be configured to only allow some certificates. When used,
-  /// [ConnectionSettings.sslMode] should be set to [SslMode.verifyFull], as
-  /// this package will allow other certificates or insecure connections
-  /// otherwise.
-  final SecurityContext? securityContext;
-
   Endpoint({
     required this.host,
     this.port = 5432,
@@ -380,7 +372,6 @@ final class Endpoint {
     this.username,
     this.password,
     this.isUnixSocket = false,
-    this.securityContext,
   });
 
   @override
@@ -415,8 +406,8 @@ enum SslMode {
   /// the security ramifications of accepting _every_ certificate: Despite using
   /// TLS, MitM attacks are possible by injecting another certificate.
   /// An alternative is using [verifyFull] with a [SecurityContext] passed to
-  /// [Endpoint.securityContext] that only accepts the known self-signed
-  /// certificate.
+  /// [ConnectionSettings.securityContext] that only accepts the known
+  /// self-signed certificate.
   require,
 
   /// Always use SSL and verify certificates.
@@ -432,6 +423,14 @@ class ConnectionSettings extends SessionSettings {
   final String? timeZone;
   final Encoding? encoding;
   final SslMode? sslMode;
+
+  /// The [SecurityContext] to use when opening a connection.
+  ///
+  /// This can be configured to only allow some certificates. When used,
+  /// [ConnectionSettings.sslMode] should be set to [SslMode.verifyFull], as
+  /// this package will allow other certificates or insecure connections
+  /// otherwise.
+  final SecurityContext? securityContext;
 
   /// An optional [StreamChannelTransformer] sitting behind the postgres client
   /// as implemented in the `posgres` package and the database server.
@@ -471,6 +470,7 @@ class ConnectionSettings extends SessionSettings {
     this.transformer,
     this.replicationMode,
     this.typeRegistry,
+    this.securityContext,
     super.connectTimeout,
     super.queryTimeout,
     super.queryMode,

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
@@ -364,6 +365,14 @@ final class Endpoint {
   final String? password;
   final bool isUnixSocket;
 
+  /// The [SecurityContext] to use when connecting to this endpoint.
+  ///
+  /// This can be configured to only allow some certificates. When used,
+  /// [ConnectionSettings.sslMode] should be set to [SslMode.verifyFull], as
+  /// this package will allow other certificates or insecure connections
+  /// otherwise.
+  final SecurityContext? securityContext;
+
   Endpoint({
     required this.host,
     this.port = 5432,
@@ -371,6 +380,7 @@ final class Endpoint {
     this.username,
     this.password,
     this.isUnixSocket = false,
+    this.securityContext,
   });
 
   @override
@@ -400,6 +410,13 @@ enum SslMode {
   disable,
 
   /// Always use SSL (but ignore verification errors).
+  ///
+  /// If you're using this option to accept self-signed certificates, consider
+  /// the security ramifications of accepting _every_ certificate: Despite using
+  /// TLS, MitM attacks are possible by injecting another certificate.
+  /// An alternative is using [verifyFull] with a [SecurityContext] passed to
+  /// [Endpoint.securityContext] that only accepts the known self-signed
+  /// certificate.
   require,
 
   /// Always use SSL and verify certificates.

--- a/lib/src/pool/pool_api.dart
+++ b/lib/src/pool/pool_api.dart
@@ -31,6 +31,7 @@ class PoolSettings extends ConnectionSettings {
     super.applicationName,
     super.connectTimeout,
     super.sslMode,
+    super.securityContext,
     super.encoding,
     super.timeZone,
     super.replicationMode,

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -285,6 +285,7 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
 
         socket = await SecureSocket.secure(
           socket,
+          context: endpoint.securityContext,
           onBadCertificate: settings.sslMode.ignoreCertificateIssues
               ? (_) => true
               : (c) => throw BadCertificateException(c),

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -285,7 +285,7 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
 
         socket = await SecureSocket.secure(
           socket,
-          context: endpoint.securityContext,
+          context: settings.securityContext,
           onBadCertificate: settings.sslMode.ignoreCertificateIssues
               ? (_) => true
               : (c) => throw BadCertificateException(c),

--- a/lib/src/v3/resolved_settings.dart
+++ b/lib/src/v3/resolved_settings.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:postgres/messages.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -47,6 +48,8 @@ class ResolvedConnectionSettings extends ResolvedSessionSettings
   @override
   final SslMode sslMode;
   @override
+  final SecurityContext? securityContext;
+  @override
   final StreamChannelTransformer<Message, Message>? transformer;
   @override
   final ReplicationMode replicationMode;
@@ -60,6 +63,7 @@ class ResolvedConnectionSettings extends ResolvedSessionSettings
         timeZone = settings?.timeZone ?? fallback?.timeZone ?? 'UTC',
         encoding = settings?.encoding ?? fallback?.encoding ?? utf8,
         sslMode = settings?.sslMode ?? fallback?.sslMode ?? SslMode.require,
+        securityContext = settings?.securityContext,
         // TODO: consider merging the transformers
         transformer = settings?.transformer ?? fallback?.transformer,
         replicationMode = settings?.replicationMode ??

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol and connection pooling.
-version: 3.0.5
+version: 3.0.6
 homepage: https://github.com/isoos/postgresql-dart
 topics:
   - sql


### PR DESCRIPTION
For self-signed certificates, we're currently forced to use `SslMode.require` and ignore certificate errors. This provides no real security on public connections though, since a MitM attack replacing the certificate with any other certificate would go undetected.

By allowing a `SecurityContext` to be passed to the secure socket upgrade method, we can let users accept some expected certificates only, and nothing else.

Unfortunately I couldn't find a good way to test this quickly - I tried loading the snakeoil cert from the container into a security context, but it would still reject it. I think we may have to setup a certificate signed by a self-signed CA for tests instead?