### PR TITLE
React to connection losses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.8
+
+- Properly react to connection losses by reporting the database connection as
+  closed.
+
 ## 3.0.7
 
 - Allow cleartext passwords when secure connection is used. ([#283](https://github.com/isoos/postgresql-dart/pull/283) by [simolus3](https://github.com/simolus3))

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -1062,13 +1062,13 @@ class _AuthenticationProcedure extends _PendingOperation {
   void handleConnectionClosed(PgException? dueToException) {
     _done.completeError(
       dueToException ?? PgException('Connection closed during authentication'),
-      StackTrace.current,
+      _trace,
     );
   }
 
   @override
   void handleError(PgException exception) {
-    _done.completeError(exception, StackTrace.current);
+    _done.completeError(exception, _trace);
 
     // If the authentication procedure fails, the connection is unusable - so we
     // might as well close it right away.

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -357,7 +357,8 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
 
   PgConnectionImplementation._(
       this._endpoint, this._settings, this._channel, this._channelIsSecure) {
-    _serverMessages = _channel.stream.listen(_handleMessage);
+    _serverMessages =
+        _channel.stream.listen(_handleMessage, onDone: _socketClosed);
   }
 
   Future<void> _startup() {
@@ -375,6 +376,15 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
 
       return result._done.future.timeout(_settings.connectTimeout);
     });
+  }
+
+  Future<void> _socketClosed() async {
+    await _close(
+      true,
+      PgException(
+          'The underlying socket to Postgres has been closed unexpectedly.'),
+      socketIsBroken: true,
+    );
   }
 
   Future<void> _handleMessage(Message message) async {
@@ -487,13 +497,16 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
     await _close(false, null);
   }
 
-  Future<void> _close(bool interruptRunning, PgException? cause) async {
+  Future<void> _close(bool interruptRunning, PgException? cause,
+      {bool socketIsBroken = false}) async {
     if (!_isClosing) {
       _isClosing = true;
 
       if (interruptRunning) {
         _pending?.handleConnectionClosed(cause);
-        _channel.sink.add(const TerminateMessage());
+        if (!socketIsBroken) {
+          _channel.sink.add(const TerminateMessage());
+        }
       } else {
         // Wait for the previous operation to complete by using the lock
         await _operationLock.withResource(() {
@@ -503,6 +516,7 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
       }
 
       await Future.wait([_channel.sink.close(), _serverMessages.cancel()]);
+      _closeSession();
     }
   }
 

--- a/lib/src/v3/protocol.dart
+++ b/lib/src/v3/protocol.dart
@@ -73,9 +73,12 @@ StreamTransformer<Uint8List, ServerMessage> _readMessages(Encoding encoding) {
         emitFinishedMessages();
       }
 
-      final rawSubscription = rawStream.listen(handleChunk)
-        ..onError(listener.addErrorSync)
-        ..onDone(listener.closeSync);
+      // Don't cancel this subscription on error! If the listener wants that,
+      // they'll unsubscribe in time after we forward it synchronously.
+      final rawSubscription =
+          rawStream.listen(handleChunk, cancelOnError: false)
+            ..onError(listener.addErrorSync)
+            ..onDone(listener.closeSync);
 
       listener.onPause = () {
         paused = true;

--- a/lib/src/v3/protocol.dart
+++ b/lib/src/v3/protocol.dart
@@ -74,7 +74,8 @@ StreamTransformer<Uint8List, ServerMessage> _readMessages(Encoding encoding) {
       }
 
       final rawSubscription = rawStream.listen(handleChunk)
-        ..onError(listener.addErrorSync);
+        ..onError(listener.addErrorSync)
+        ..onDone(listener.closeSync);
 
       listener.onPause = () {
         paused = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol and connection pooling.
-version: 3.0.7
+version: 3.0.8
 homepage: https://github.com/isoos/postgresql-dart
 topics:
   - sql

--- a/test/docker.dart
+++ b/test/docker.dart
@@ -74,6 +74,10 @@ class PostgresServer {
       ),
     );
   }
+
+  Future<void> kill() async {
+    await Process.run('docker', ['kill', await _containerName.future]);
+  }
 }
 
 @isTestGroup

--- a/test/v3_test.dart
+++ b/test/v3_test.dart
@@ -483,6 +483,22 @@ void main() {
           'select pg_terminate_backend($conn1PID) from pg_stat_activity;');
     });
   });
+
+  withPostgresServer('reacts to socket being closed', (server) {
+    test('when killing server', () async {
+      final conn = await server.newConnection();
+      var isClosed = false;
+      unawaited(conn.closed.whenComplete(() => isClosed = true));
+
+      expect(isClosed, isFalse);
+      await conn.execute('select 1');
+      expect(isClosed, isFalse);
+
+      await server.kill();
+      await conn.closed;
+      expect(isClosed, isTrue);
+    });
+  });
 }
 
 final _isPostgresException = isA<PgException>();


### PR DESCRIPTION
When postgres wants to shut a connection down, it usually sends a terminate message first. But if the server gets killed or the TCP socket is dropped due to connectivity changes, we should still detect that and wind the connection down gracefully (more or less, without connectivity).

With this PR, the connection will react to the stream closing by reporting pending operations as failed. Further, it will complete the `closed` future, allowing clients to reliably detect closing connections.

The second commit closes https://github.com/isoos/postgresql-dart/issues/279.