### PR TITLE
Add builtin time, geometric and most range types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.9
+
+Added the following PostgreSQL builtin types:
+- Geometric types `line`, `lseg`,`path`,`polygon`,`box`,`circle`
+- Range types `int4range`, `int8range`, `daterange`, `tsrange`,`tstzrange`
+- Time type `time`
+
 ## 3.0.8
 
 - Properly react to connection losses by reporting the database connection as
@@ -7,7 +14,9 @@
 
 ## 3.0.7
 
-- Allow cleartext passwords when secure connection is used. ([#283](https://github.com/isoos/postgresql-dart/pull/283) by [simolus3](https://github.com/simolus3))
+- Allow cleartext passwords when secure connection is
+  used. ([#283](https://github.com/isoos/postgresql-dart/pull/283)
+  by [simolus3](https://github.com/simolus3))
 
 ## 3.0.6
 
@@ -23,13 +32,17 @@
 
 ## 3.0.3
 
-- Using const for ConnectionSettings, SessionSettings and PoolSettings classes. ([#267](https://github.com/isoos/postgresql-dart/pull/267) by [Gerrel](https://github.com/Gerrel))
+- Using const for ConnectionSettings, SessionSettings and PoolSettings
+  classes. ([#267](https://github.com/isoos/postgresql-dart/pull/267)
+  by [Gerrel](https://github.com/Gerrel))
 - Parsing of `Sql.indexed` and `Sql.named` happens when the `Connection` starts
   to interpret it. Errors with unknown type names are thrown in this later step.
 
 ## 3.0.2
 
-- Fix: Dispose disconnected pool `Connection`s. ([#260](https://github.com/isoos/postgresql-dart/pull/260) by [nehzata](https://github.com/nehzata)).
+- Fix: Dispose disconnected pool `Connection`
+  s. ([#260](https://github.com/isoos/postgresql-dart/pull/260)
+  by [nehzata](https://github.com/nehzata)).
 - Deprecated `ParseMessage` constructor's `types` argument, use `typeOids` instead.
   (As most users don't access this directly, it will be removed in `3.1.0`).
 
@@ -59,21 +72,21 @@ behaviour, keeping most of the wire protocol handling from the old version.
 
 Notable breaking behaviour changes:
 
-  - Simple query protocol allows sending queries to the server without
-    awaiting on the result. The new implementation queues these request
-    on the client instead.
-  - Table name OIDs are not fetched or cached, this information from the
-    result schema is absent, also causing `mappedResultsQuery` to be
-    removed from the new API.
-  - Queries are not cached implicitly, explicit prepared statements can be
-    used instead.
-  - `interval` values are returned as `Interval` type instead of `Duration`.
-  - A newly added `UndecodedBytes` instances are returned when the package does
-    not know or has not implemented the appropriate type decoding yet.
-    Previously these values were auto-encoded to `String` and if that failed
-    the `Uint8List` were used.
-  - Types, fields and parameter names may have been renamed to be more
-    consistent or more aligned with the Dart naming guides.
+- Simple query protocol allows sending queries to the server without
+  awaiting on the result. The new implementation queues these request
+  on the client instead.
+- Table name OIDs are not fetched or cached, this information from the
+  result schema is absent, also causing `mappedResultsQuery` to be
+  removed from the new API.
+- Queries are not cached implicitly, explicit prepared statements can be
+  used instead.
+- `interval` values are returned as `Interval` type instead of `Duration`.
+- A newly added `UndecodedBytes` instances are returned when the package does
+  not know or has not implemented the appropriate type decoding yet.
+  Previously these values were auto-encoded to `String` and if that failed
+  the `Uint8List` were used.
+- Types, fields and parameter names may have been renamed to be more
+  consistent or more aligned with the Dart naming guides.
 
 ### Legacy compatibility layer
 
@@ -83,13 +96,13 @@ the ones mentioned above are missing and/or throw `UnimplementedError` when call
 
 ### Migration
 
-  - You may use the legacy compatibility layer to check if your code relies on
-    any of the above mentioned feature, rewrite if needed.
-  - Start using the new API, incrementally, when possible.
-  - For most queries, you may use `Sql.named('SELECT ...')` to keep the default
-    name- and `Map`-based query `@variable`` substitution, or you may use the
-    raw `$1` version (with 1-based indexes).
-  - Always write tests.
+- You may use the legacy compatibility layer to check if your code relies on
+  any of the above mentioned feature, rewrite if needed.
+- Start using the new API, incrementally, when possible.
+- For most queries, you may use `Sql.named('SELECT ...')` to keep the default
+  name- and `Map`-based query `@variable`` substitution, or you may use the
+  raw `$1` version (with 1-based indexes).
+- Always write tests.
 
 If you have any issues with migration or with the new behavior, please open an
 issue on the package's GitHub issue tracker or discussions.
@@ -115,20 +128,25 @@ who helped to push forward.
 
 ## 2.6.3
 
-- Allow `encoding` to be specified for connections. The setting will be used for all connection-related string conversions.
-- Allow generic `List` type as substitution values in binary encoding (as long as the inner type matches).
+- Allow `encoding` to be specified for connections. The setting will be used for all
+  connection-related string conversions.
+- Allow generic `List` type as substitution values in binary encoding (as long as the inner type
+  matches).
 - Refactor: replaced `UTF8BackedString` with generic encoding (not complete).
-- Breaking change in `package:postgres/messages.dart`: default constructors made internal, parsing is done with more efficient reader.
+- Breaking change in `package:postgres/messages.dart`: default constructors made internal, parsing
+  is done with more efficient reader.
 
 ## 2.6.2
 
 - Improved (experimental) v3 implementation.
   [#98](https://github.com/isoos/postgresql-dart/pull/98) and
-  [#102](https://github.com/isoos/postgresql-dart/pull/102) by [simolus3](https://github.com/simolus3).
+  [#102](https://github.com/isoos/postgresql-dart/pull/102)
+  by [simolus3](https://github.com/simolus3).
 
 ## 2.6.1
 
-- Added support for bigInt (int8) arrays. [#41](https://github.com/isoos/postgresql-dart/pull/88) by [schultek](https://github.com/schultek).
+- Added support for bigInt (int8) arrays. [#41](https://github.com/isoos/postgresql-dart/pull/88)
+  by [schultek](https://github.com/schultek).
 
 ## 2.6.0
 
@@ -142,52 +160,77 @@ who helped to push forward.
 
 ## 2.5.2
 
-- Connecting without a password for non-trusted users throws an exception instead of timing out [#68](https://github.com/isoos/postgresql-dart/pull/68) by [osaxma](https://github.com/osaxma).
+- Connecting without a password for non-trusted users throws an exception instead of timing
+  out [#68](https://github.com/isoos/postgresql-dart/pull/68)
+  by [osaxma](https://github.com/osaxma).
 
 ## 2.5.1
 
-- Use `substitutionValues` with `useSimpleQueryProtocol` [#62](https://github.com/isoos/postgresql-dart/pull/62) by [osaxma](https://github.com/osaxma)
+- Use `substitutionValues`
+  with `useSimpleQueryProtocol` [#62](https://github.com/isoos/postgresql-dart/pull/62)
+  by [osaxma](https://github.com/osaxma)
 
 ## 2.5.0
 
 - Added Support for Streaming Replication Protocol which included the following changes:
-  - Replication Mode Messages Handling. [#58](https://github.com/isoos/postgresql-dart/pull/58) by [osaxma](https://github.com/osaxma)
-  - Add new message types for replication. [#57](https://github.com/isoos/postgresql-dart/pull/57) by [osaxma](https://github.com/osaxma)
-  - Add connection configuration for Streaming Replication Protocol. [#56](https://github.com/isoos/postgresql-dart/pull/56) by [osaxma](https://github.com/osaxma)
-  - Raise the min sdk version to support enhanced enums. [#55](https://github.com/isoos/postgresql-dart/pull/55) by [osaxma](https://github.com/osaxma)
-  - Add LSN type and time conversion to and from ms-since-Y2K. [#53](https://github.com/isoos/postgresql-dart/pull/53) by [osaxma](https://github.com/osaxma)
-  - Fix affected rows parsing in CommandCompleteMessage. [#52](https://github.com/isoos/postgresql-dart/pull/52) by [osaxma](https://github.com/osaxma)
-  - Introduced new APIs to `PostgreSQLConnection`: `addMessage` to send client messages, `messages` stream to listen to server messages & `useSimpleQueryProtocol` option in `query` method. [#51](https://github.com/isoos/postgresql-dart/pull/51) by [osaxma](https://github.com/osaxma)
+    - Replication Mode Messages Handling. [#58](https://github.com/isoos/postgresql-dart/pull/58)
+      by [osaxma](https://github.com/osaxma)
+    - Add new message types for replication. [#57](https://github.com/isoos/postgresql-dart/pull/57)
+      by [osaxma](https://github.com/osaxma)
+    - Add connection configuration for Streaming Replication
+      Protocol. [#56](https://github.com/isoos/postgresql-dart/pull/56)
+      by [osaxma](https://github.com/osaxma)
+    - Raise the min sdk version to support enhanced
+      enums. [#55](https://github.com/isoos/postgresql-dart/pull/55)
+      by [osaxma](https://github.com/osaxma)
+    - Add LSN type and time conversion to and from
+      ms-since-Y2K. [#53](https://github.com/isoos/postgresql-dart/pull/53)
+      by [osaxma](https://github.com/osaxma)
+    - Fix affected rows parsing in
+      CommandCompleteMessage. [#52](https://github.com/isoos/postgresql-dart/pull/52)
+      by [osaxma](https://github.com/osaxma)
+    - Introduced new APIs to `PostgreSQLConnection`: `addMessage` to send client
+      messages, `messages` stream to listen to server messages & `useSimpleQueryProtocol` option
+      in `query` method. [#51](https://github.com/isoos/postgresql-dart/pull/51)
+      by [osaxma](https://github.com/osaxma)
 
 ## 2.4.6
 
 - Fix crash when manually issuing a transaction statement like `BEGIN` without
-  using the high-level transaction APIs. [#47](https://github.com/isoos/postgresql-dart/pull/47) by [simolus3](https://github.com/simolus3).
+  using the high-level transaction APIs. [#47](https://github.com/isoos/postgresql-dart/pull/47)
+  by [simolus3](https://github.com/simolus3).
 
 ## 2.4.5
 
-- Added support for boolean arrays. [#41](https://github.com/isoos/postgresql-dart/pull/41) by [slightfoot](https://github.com/slightfoot).
+- Added support for boolean arrays. [#41](https://github.com/isoos/postgresql-dart/pull/41)
+  by [slightfoot](https://github.com/slightfoot).
 
 ## 2.4.4
 
-- Added support for varchar arrays. [#39](https://github.com/isoos/postgresql-dart/pull/39) by [paschalisp](https://github.com/paschalisp).
+- Added support for varchar arrays. [#39](https://github.com/isoos/postgresql-dart/pull/39)
+  by [paschalisp](https://github.com/paschalisp).
 
 ## 2.4.3
 
-- Support for clear text passwords using a boolean parameter in connection as 'allowClearTextPassword' to activate / deactivate the feature. [#20](https://github.com/isoos/postgresql-dart/pull/20).
+- Support for clear text passwords using a boolean parameter in connection as '
+  allowClearTextPassword' to activate / deactivate the
+  feature. [#20](https://github.com/isoos/postgresql-dart/pull/20).
 
 ## 2.4.2
 
 - Include original stacktrace when query fails.
-  ([#15](https://github.com/isoos/postgresql-dart/pull/15) by [davidmartos96](https://github.com/davidmartos96))
+  ([#15](https://github.com/isoos/postgresql-dart/pull/15)
+  by [davidmartos96](https://github.com/davidmartos96))
 
 ## 2.4.1+2
 
-- Fix error when sending json data with `execute()` [#11](https://github.com/isoos/postgresql-dart/pull/11)
+- Fix error when sending json data
+  with `execute()` [#11](https://github.com/isoos/postgresql-dart/pull/11)
 
 ## 2.4.1+1
 
-- Fix error when passing `allowReuse: null` into `query()` [#8](https://github.com/isoos/postgresql-dart/pull/8)
+- Fix error when passing `allowReuse: null`
+  into `query()` [#8](https://github.com/isoos/postgresql-dart/pull/8)
 
 ## 2.4.1
 
@@ -195,8 +238,10 @@ who helped to push forward.
 
 ## 2.4.0
 
-- Support for type `numeric` / `decimal` ([#7](https://github.com/isoos/postgresql-dart/pull/7), [#9](https://github.com/isoos/postgresql-dart/pull/9)).
-- Support SASL / SCRAM-SHA-256 Authentication, [#6](https://github.com/isoos/postgresql-dart/pull/6).
+- Support for
+  type `numeric` / `decimal` ([#7](https://github.com/isoos/postgresql-dart/pull/7), [#9](https://github.com/isoos/postgresql-dart/pull/9)).
+- Support SASL / SCRAM-SHA-256
+  Authentication, [#6](https://github.com/isoos/postgresql-dart/pull/6).
 
 ## 2.3.2
 
@@ -204,8 +249,10 @@ who helped to push forward.
 
 ## 2.3.1
 
-- Added support for types `varchar`, `point`, `integerArray`, `doubleArray`, `textArray` and `jsonArray`.
-  (Thanks to [schultek](https://github.com/schultek), [#3](https://github.com/isoos/postgresql-dart/pull/3))
+- Added support for types `varchar`, `point`, `integerArray`, `doubleArray`, `textArray`
+  and `jsonArray`.
+  (Thanks
+  to [schultek](https://github.com/schultek), [#3](https://github.com/isoos/postgresql-dart/pull/3))
 
 ## 2.3.0
 
@@ -222,7 +269,8 @@ who helped to push forward.
 
 ## 2.3.0-null-safety.0
 
-- Migrate to null safety. (Thanks to [j4qfrost](https://github.com/j4qfrost), [#153](https://github.com/stablekernel/postgresql-dart/pull/153)).
+- Migrate to null safety. (Thanks
+  to [j4qfrost](https://github.com/j4qfrost), [#153](https://github.com/stablekernel/postgresql-dart/pull/153)).
 - Documentation fix (by [saward](https://github.com/saward)).
 
 ## 2.2.0
@@ -256,9 +304,9 @@ who helped to push forward.
 - Hardened codebase with `package:pedantic` and additional lints.
 - Updated codebase to Dart 2.2.
 - `PostgreSQLResult` and `PostgreSQLResultRow` as the return value of a query.
-  - Returned lists are protected with `UnmodifiableListView`.
-  - Exposing column metadata through `ColumnDescription`.
-  - row-level `toTableColumnMap` and `toColumnMap`
+    - Returned lists are protected with `UnmodifiableListView`.
+    - Exposing column metadata through `ColumnDescription`.
+    - row-level `toTableColumnMap` and `toColumnMap`
 - `PostgreSQLConnection` and `_TransactionProxy` share the OID cache.
 - default value for `query(allowReuse = true)` is set only in the implementation method.
 
@@ -267,6 +315,7 @@ who helped to push forward.
 - Table OIDs are always resolved to table names (and not only with mapped queries).
 
 ## 1.0.2
+
 - Add connection queue size
 
 ## 1.0.1
@@ -288,7 +337,8 @@ who helped to push forward.
 
 ## 0.9.7
 
-- Adds `Connection.mappedResultsQuery` to return query results as a `Map` with keys for table and column names.
+- Adds `Connection.mappedResultsQuery` to return query results as a `Map` with keys for table and
+  column names.
 
 ## 0.9.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,7 @@ Added the following PostgreSQL builtin types:
 
 ## 3.0.7
 
-- Allow cleartext passwords when secure connection is
-  used. ([#283](https://github.com/isoos/postgresql-dart/pull/283)
-  by [simolus3](https://github.com/simolus3))
+- Allow cleartext passwords when secure connection is used. ([#283](https://github.com/isoos/postgresql-dart/pull/283) by [simolus3](https://github.com/simolus3))
 
 ## 3.0.6
 
@@ -32,17 +30,13 @@ Added the following PostgreSQL builtin types:
 
 ## 3.0.3
 
-- Using const for ConnectionSettings, SessionSettings and PoolSettings
-  classes. ([#267](https://github.com/isoos/postgresql-dart/pull/267)
-  by [Gerrel](https://github.com/Gerrel))
+- Using const for ConnectionSettings, SessionSettings and PoolSettings classes. ([#267](https://github.com/isoos/postgresql-dart/pull/267) by [Gerrel](https://github.com/Gerrel))
 - Parsing of `Sql.indexed` and `Sql.named` happens when the `Connection` starts
   to interpret it. Errors with unknown type names are thrown in this later step.
 
 ## 3.0.2
 
-- Fix: Dispose disconnected pool `Connection`
-  s. ([#260](https://github.com/isoos/postgresql-dart/pull/260)
-  by [nehzata](https://github.com/nehzata)).
+- Fix: Dispose disconnected pool `Connection`s. ([#260](https://github.com/isoos/postgresql-dart/pull/260) by [nehzata](https://github.com/nehzata)).
 - Deprecated `ParseMessage` constructor's `types` argument, use `typeOids` instead.
   (As most users don't access this directly, it will be removed in `3.1.0`).
 
@@ -72,21 +66,21 @@ behaviour, keeping most of the wire protocol handling from the old version.
 
 Notable breaking behaviour changes:
 
-- Simple query protocol allows sending queries to the server without
-  awaiting on the result. The new implementation queues these request
-  on the client instead.
-- Table name OIDs are not fetched or cached, this information from the
-  result schema is absent, also causing `mappedResultsQuery` to be
-  removed from the new API.
-- Queries are not cached implicitly, explicit prepared statements can be
-  used instead.
-- `interval` values are returned as `Interval` type instead of `Duration`.
-- A newly added `UndecodedBytes` instances are returned when the package does
-  not know or has not implemented the appropriate type decoding yet.
-  Previously these values were auto-encoded to `String` and if that failed
-  the `Uint8List` were used.
-- Types, fields and parameter names may have been renamed to be more
-  consistent or more aligned with the Dart naming guides.
+  - Simple query protocol allows sending queries to the server without
+    awaiting on the result. The new implementation queues these request
+    on the client instead.
+  - Table name OIDs are not fetched or cached, this information from the
+    result schema is absent, also causing `mappedResultsQuery` to be
+    removed from the new API.
+  - Queries are not cached implicitly, explicit prepared statements can be
+    used instead.
+  - `interval` values are returned as `Interval` type instead of `Duration`.
+  - A newly added `UndecodedBytes` instances are returned when the package does
+    not know or has not implemented the appropriate type decoding yet.
+    Previously these values were auto-encoded to `String` and if that failed
+    the `Uint8List` were used.
+  - Types, fields and parameter names may have been renamed to be more
+    consistent or more aligned with the Dart naming guides.
 
 ### Legacy compatibility layer
 
@@ -96,13 +90,13 @@ the ones mentioned above are missing and/or throw `UnimplementedError` when call
 
 ### Migration
 
-- You may use the legacy compatibility layer to check if your code relies on
-  any of the above mentioned feature, rewrite if needed.
-- Start using the new API, incrementally, when possible.
-- For most queries, you may use `Sql.named('SELECT ...')` to keep the default
-  name- and `Map`-based query `@variable`` substitution, or you may use the
-  raw `$1` version (with 1-based indexes).
-- Always write tests.
+  - You may use the legacy compatibility layer to check if your code relies on
+    any of the above mentioned feature, rewrite if needed.
+  - Start using the new API, incrementally, when possible.
+  - For most queries, you may use `Sql.named('SELECT ...')` to keep the default
+    name- and `Map`-based query `@variable`` substitution, or you may use the
+    raw `$1` version (with 1-based indexes).
+  - Always write tests.
 
 If you have any issues with migration or with the new behavior, please open an
 issue on the package's GitHub issue tracker or discussions.
@@ -128,25 +122,20 @@ who helped to push forward.
 
 ## 2.6.3
 
-- Allow `encoding` to be specified for connections. The setting will be used for all
-  connection-related string conversions.
-- Allow generic `List` type as substitution values in binary encoding (as long as the inner type
-  matches).
+- Allow `encoding` to be specified for connections. The setting will be used for all connection-related string conversions.
+- Allow generic `List` type as substitution values in binary encoding (as long as the inner type matches).
 - Refactor: replaced `UTF8BackedString` with generic encoding (not complete).
-- Breaking change in `package:postgres/messages.dart`: default constructors made internal, parsing
-  is done with more efficient reader.
+- Breaking change in `package:postgres/messages.dart`: default constructors made internal, parsing is done with more efficient reader.
 
 ## 2.6.2
 
 - Improved (experimental) v3 implementation.
   [#98](https://github.com/isoos/postgresql-dart/pull/98) and
-  [#102](https://github.com/isoos/postgresql-dart/pull/102)
-  by [simolus3](https://github.com/simolus3).
+  [#102](https://github.com/isoos/postgresql-dart/pull/102) by [simolus3](https://github.com/simolus3).
 
 ## 2.6.1
 
-- Added support for bigInt (int8) arrays. [#41](https://github.com/isoos/postgresql-dart/pull/88)
-  by [schultek](https://github.com/schultek).
+- Added support for bigInt (int8) arrays. [#41](https://github.com/isoos/postgresql-dart/pull/88) by [schultek](https://github.com/schultek).
 
 ## 2.6.0
 
@@ -160,77 +149,52 @@ who helped to push forward.
 
 ## 2.5.2
 
-- Connecting without a password for non-trusted users throws an exception instead of timing
-  out [#68](https://github.com/isoos/postgresql-dart/pull/68)
-  by [osaxma](https://github.com/osaxma).
+- Connecting without a password for non-trusted users throws an exception instead of timing out [#68](https://github.com/isoos/postgresql-dart/pull/68) by [osaxma](https://github.com/osaxma).
 
 ## 2.5.1
 
-- Use `substitutionValues`
-  with `useSimpleQueryProtocol` [#62](https://github.com/isoos/postgresql-dart/pull/62)
-  by [osaxma](https://github.com/osaxma)
+- Use `substitutionValues` with `useSimpleQueryProtocol` [#62](https://github.com/isoos/postgresql-dart/pull/62) by [osaxma](https://github.com/osaxma)
 
 ## 2.5.0
 
 - Added Support for Streaming Replication Protocol which included the following changes:
-    - Replication Mode Messages Handling. [#58](https://github.com/isoos/postgresql-dart/pull/58)
-      by [osaxma](https://github.com/osaxma)
-    - Add new message types for replication. [#57](https://github.com/isoos/postgresql-dart/pull/57)
-      by [osaxma](https://github.com/osaxma)
-    - Add connection configuration for Streaming Replication
-      Protocol. [#56](https://github.com/isoos/postgresql-dart/pull/56)
-      by [osaxma](https://github.com/osaxma)
-    - Raise the min sdk version to support enhanced
-      enums. [#55](https://github.com/isoos/postgresql-dart/pull/55)
-      by [osaxma](https://github.com/osaxma)
-    - Add LSN type and time conversion to and from
-      ms-since-Y2K. [#53](https://github.com/isoos/postgresql-dart/pull/53)
-      by [osaxma](https://github.com/osaxma)
-    - Fix affected rows parsing in
-      CommandCompleteMessage. [#52](https://github.com/isoos/postgresql-dart/pull/52)
-      by [osaxma](https://github.com/osaxma)
-    - Introduced new APIs to `PostgreSQLConnection`: `addMessage` to send client
-      messages, `messages` stream to listen to server messages & `useSimpleQueryProtocol` option
-      in `query` method. [#51](https://github.com/isoos/postgresql-dart/pull/51)
-      by [osaxma](https://github.com/osaxma)
+  - Replication Mode Messages Handling. [#58](https://github.com/isoos/postgresql-dart/pull/58) by [osaxma](https://github.com/osaxma)
+  - Add new message types for replication. [#57](https://github.com/isoos/postgresql-dart/pull/57) by [osaxma](https://github.com/osaxma)
+  - Add connection configuration for Streaming Replication Protocol. [#56](https://github.com/isoos/postgresql-dart/pull/56) by [osaxma](https://github.com/osaxma)
+  - Raise the min sdk version to support enhanced enums. [#55](https://github.com/isoos/postgresql-dart/pull/55) by [osaxma](https://github.com/osaxma)
+  - Add LSN type and time conversion to and from ms-since-Y2K. [#53](https://github.com/isoos/postgresql-dart/pull/53) by [osaxma](https://github.com/osaxma)
+  - Fix affected rows parsing in CommandCompleteMessage. [#52](https://github.com/isoos/postgresql-dart/pull/52) by [osaxma](https://github.com/osaxma)
+  - Introduced new APIs to `PostgreSQLConnection`: `addMessage` to send client messages, `messages` stream to listen to server messages & `useSimpleQueryProtocol` option in `query` method. [#51](https://github.com/isoos/postgresql-dart/pull/51) by [osaxma](https://github.com/osaxma)
 
 ## 2.4.6
 
 - Fix crash when manually issuing a transaction statement like `BEGIN` without
-  using the high-level transaction APIs. [#47](https://github.com/isoos/postgresql-dart/pull/47)
-  by [simolus3](https://github.com/simolus3).
+  using the high-level transaction APIs. [#47](https://github.com/isoos/postgresql-dart/pull/47) by [simolus3](https://github.com/simolus3).
 
 ## 2.4.5
 
-- Added support for boolean arrays. [#41](https://github.com/isoos/postgresql-dart/pull/41)
-  by [slightfoot](https://github.com/slightfoot).
+- Added support for boolean arrays. [#41](https://github.com/isoos/postgresql-dart/pull/41) by [slightfoot](https://github.com/slightfoot).
 
 ## 2.4.4
 
-- Added support for varchar arrays. [#39](https://github.com/isoos/postgresql-dart/pull/39)
-  by [paschalisp](https://github.com/paschalisp).
+- Added support for varchar arrays. [#39](https://github.com/isoos/postgresql-dart/pull/39) by [paschalisp](https://github.com/paschalisp).
 
 ## 2.4.3
 
-- Support for clear text passwords using a boolean parameter in connection as '
-  allowClearTextPassword' to activate / deactivate the
-  feature. [#20](https://github.com/isoos/postgresql-dart/pull/20).
+- Support for clear text passwords using a boolean parameter in connection as 'allowClearTextPassword' to activate / deactivate the feature. [#20](https://github.com/isoos/postgresql-dart/pull/20).
 
 ## 2.4.2
 
 - Include original stacktrace when query fails.
-  ([#15](https://github.com/isoos/postgresql-dart/pull/15)
-  by [davidmartos96](https://github.com/davidmartos96))
+  ([#15](https://github.com/isoos/postgresql-dart/pull/15) by [davidmartos96](https://github.com/davidmartos96))
 
 ## 2.4.1+2
 
-- Fix error when sending json data
-  with `execute()` [#11](https://github.com/isoos/postgresql-dart/pull/11)
+- Fix error when sending json data with `execute()` [#11](https://github.com/isoos/postgresql-dart/pull/11)
 
 ## 2.4.1+1
 
-- Fix error when passing `allowReuse: null`
-  into `query()` [#8](https://github.com/isoos/postgresql-dart/pull/8)
+- Fix error when passing `allowReuse: null` into `query()` [#8](https://github.com/isoos/postgresql-dart/pull/8)
 
 ## 2.4.1
 
@@ -238,10 +202,8 @@ who helped to push forward.
 
 ## 2.4.0
 
-- Support for
-  type `numeric` / `decimal` ([#7](https://github.com/isoos/postgresql-dart/pull/7), [#9](https://github.com/isoos/postgresql-dart/pull/9)).
-- Support SASL / SCRAM-SHA-256
-  Authentication, [#6](https://github.com/isoos/postgresql-dart/pull/6).
+- Support for type `numeric` / `decimal` ([#7](https://github.com/isoos/postgresql-dart/pull/7), [#9](https://github.com/isoos/postgresql-dart/pull/9)).
+- Support SASL / SCRAM-SHA-256 Authentication, [#6](https://github.com/isoos/postgresql-dart/pull/6).
 
 ## 2.3.2
 
@@ -249,10 +211,8 @@ who helped to push forward.
 
 ## 2.3.1
 
-- Added support for types `varchar`, `point`, `integerArray`, `doubleArray`, `textArray`
-  and `jsonArray`.
-  (Thanks
-  to [schultek](https://github.com/schultek), [#3](https://github.com/isoos/postgresql-dart/pull/3))
+- Added support for types `varchar`, `point`, `integerArray`, `doubleArray`, `textArray` and `jsonArray`.
+  (Thanks to [schultek](https://github.com/schultek), [#3](https://github.com/isoos/postgresql-dart/pull/3))
 
 ## 2.3.0
 
@@ -269,8 +229,7 @@ who helped to push forward.
 
 ## 2.3.0-null-safety.0
 
-- Migrate to null safety. (Thanks
-  to [j4qfrost](https://github.com/j4qfrost), [#153](https://github.com/stablekernel/postgresql-dart/pull/153)).
+- Migrate to null safety. (Thanks to [j4qfrost](https://github.com/j4qfrost), [#153](https://github.com/stablekernel/postgresql-dart/pull/153)).
 - Documentation fix (by [saward](https://github.com/saward)).
 
 ## 2.2.0
@@ -304,9 +263,9 @@ who helped to push forward.
 - Hardened codebase with `package:pedantic` and additional lints.
 - Updated codebase to Dart 2.2.
 - `PostgreSQLResult` and `PostgreSQLResultRow` as the return value of a query.
-    - Returned lists are protected with `UnmodifiableListView`.
-    - Exposing column metadata through `ColumnDescription`.
-    - row-level `toTableColumnMap` and `toColumnMap`
+  - Returned lists are protected with `UnmodifiableListView`.
+  - Exposing column metadata through `ColumnDescription`.
+  - row-level `toTableColumnMap` and `toColumnMap`
 - `PostgreSQLConnection` and `_TransactionProxy` share the OID cache.
 - default value for `query(allowReuse = true)` is set only in the implementation method.
 
@@ -315,7 +274,6 @@ who helped to push forward.
 - Table OIDs are always resolved to table names (and not only with mapped queries).
 
 ## 1.0.2
-
 - Add connection queue size
 
 ## 1.0.1
@@ -337,8 +295,7 @@ who helped to push forward.
 
 ## 0.9.7
 
-- Adds `Connection.mappedResultsQuery` to return query results as a `Map` with keys for table and
-  column names.
+- Adds `Connection.mappedResultsQuery` to return query results as a `Map` with keys for table and column names.
 
 ## 0.9.6
 

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -17,6 +17,8 @@ export 'src/exceptions.dart';
 export 'src/pool/pool_api.dart';
 export 'src/replication.dart';
 export 'src/types.dart';
+export 'src/types/geo_types.dart';
+export 'src/types/range_types.dart' hide Range, DiscreteRange, ContinuousRange;
 export 'src/types/type_registry.dart' show TypeRegistry;
 
 /// A description of a SQL query as interpreted by this package.
@@ -227,6 +229,7 @@ abstract class ResultStream implements Stream<ResultRow> {
 abstract class ResultStreamSubscription
     implements StreamSubscription<ResultRow> {
   Future<int> get affectedRows;
+
   Future<ResultSchema> get schema;
 }
 
@@ -335,7 +338,9 @@ abstract class Channels {
   Stream<Notification> get all;
 
   Stream<String> operator [](String channel);
+
   Future<void> notify(String channel, [String? payload]);
+
   Future<void> cancelAll();
 }
 
@@ -415,6 +420,7 @@ enum SslMode {
   ;
 
   bool get ignoreCertificateIssues => this == SslMode.require;
+
   bool get allowCleartextPassword => this == SslMode.disable;
 }
 

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -18,7 +18,7 @@ export 'src/pool/pool_api.dart';
 export 'src/replication.dart';
 export 'src/types.dart';
 export 'src/types/geo_types.dart';
-export 'src/types/range_types.dart' hide Range, DiscreteRange, ContinuousRange;
+export 'src/types/range_types.dart';
 export 'src/types/type_registry.dart' show TypeRegistry;
 
 /// A description of a SQL query as interpreted by this package.

--- a/lib/src/messages/server_messages.dart
+++ b/lib/src/messages/server_messages.dart
@@ -409,7 +409,7 @@ class UnknownMessage extends ServerMessage {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other is! UnknownMessage) {
       return false;
     }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
-import 'dart:core';
 import 'dart:core' as core;
+import 'dart:core';
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 
 import 'types/generic_type.dart';
+import 'types/geo_types.dart';
+import 'types/range_types.dart';
 import 'types/type_registry.dart';
 
 /// In Postgresql `interval` values are stored as [months], [days], and [microseconds].
@@ -119,27 +121,83 @@ class LSN {
   int get hashCode => value.hashCode;
 }
 
-/// Describes PostgreSQL's geometric type: `point`.
-@immutable
-class Point {
-  /// also referred as `x`
-  final double latitude;
+/// Describes PostgreSQL's `time without time zone` type.
+///
+/// See https://www.postgresql.org/docs/current/datatype-datetime.html
+///
+/// `time with time zone` is not implemented as Postgres wiki recommends against its use:
+///
+/// https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_timetz
+class Time {
+  /// The time in microseconds
+  late final int microseconds;
 
-  /// also referred as `y`
-  final double longitude;
+  /// Construct a [Time] instance from [microseconds].
+  ///
+  /// [microseconds] must be positive and not resolve to a time larger than 24:00:00.000000.
+  Time.fromMicroseconds(this.microseconds) {
+    _check();
+  }
 
-  const Point(this.latitude, this.longitude);
+  /// Construct a [Time] instance.
+  ///
+  /// [Time] value must be positive and not larger than 24:00:00.000000.
+  Time(
+      [int hour = 0,
+      int minute = 0,
+      int second = 0,
+      int millisecond = 0,
+      int microsecond = 0]) {
+    microseconds = hour * Duration.microsecondsPerHour +
+        minute * Duration.microsecondsPerMinute +
+        second * Duration.microsecondsPerSecond +
+        millisecond * Duration.microsecondsPerMillisecond +
+        microsecond;
+    _check();
+  }
+
+  _check() {
+    if (microseconds > Duration.microsecondsPerDay) {
+      throw ArgumentError(
+          'Time: values greater than 24:00:00.000000 are not allowed');
+    }
+    if (microseconds < 0) {
+      throw ArgumentError('Time: negative value not allowed');
+    }
+  }
+
+  DateTime get utcDateTime =>
+      DateTime.fromMicrosecondsSinceEpoch(microseconds, isUtc: true);
+
+  /// The hour of the day, expressed as in a 25-hour clock `0...24`.
+  int get hour => microseconds == Duration.microsecondsPerDay ? 24 : 0;
+
+  /// The minute `[0...59]`.
+  int get minute => utcDateTime.minute;
+
+  /// The second `[0...59]`.
+  int get second => utcDateTime.second;
+
+  /// The millisecond `[0...999]`.
+  int get millisecond => utcDateTime.millisecond;
+
+  /// The microsecond `[0...999]`.
+  int get microsecond => utcDateTime.microsecond;
+
+  @override
+  String toString() => microseconds == Duration.microsecondsPerDay
+      ? 'Time(24:00:00.000)'
+      : 'Time(${utcDateTime.toIso8601String().split('T')[1].replaceAll('Z', '')})';
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is Point &&
+      other is Time &&
           runtimeType == other.runtimeType &&
-          latitude == other.latitude &&
-          longitude == other.longitude;
+          microseconds == other.microseconds;
 
   @override
-  int get hashCode => Object.hash(latitude, longitude);
+  int get hashCode => microseconds;
 }
 
 /// Supported data types.
@@ -176,6 +234,9 @@ abstract class Type<T extends Object> {
 
   /// Must be a [bool]
   static const boolean = GenericType<bool>(TypeOid.boolean);
+
+  /// Must be a [Time]
+  static const time = GenericType<Time>(TypeOid.time);
 
   /// Must be a [DateTime] (microsecond date and time precision)
   static const timestampWithoutTimezone =
@@ -227,6 +288,24 @@ abstract class Type<T extends Object> {
   /// Must be a [Point]
   static const point = GenericType<Point>(TypeOid.point);
 
+  /// Must be a [Line]
+  static const line = GenericType<Line>(TypeOid.line);
+
+  /// Must be a [Lseg]
+  static const lseg = GenericType<Lseg>(TypeOid.lseg);
+
+  /// Must be a [Box]
+  static const box = GenericType<Box>(TypeOid.box);
+
+  /// Must be a [Polygon]
+  static const polygon = GenericType<Polygon>(TypeOid.polygon);
+
+  /// Must be a [Path]
+  static const path = GenericType<Path>(TypeOid.path);
+
+  /// Must be a [Circle]
+  static const circle = GenericType<Circle>(TypeOid.circle);
+
   /// Must be a [List<bool>]
   static const booleanArray = GenericType<List<bool>>(TypeOid.booleanArray);
 
@@ -258,6 +337,27 @@ abstract class Type<T extends Object> {
 
   /// Impossible to bind to, always null when read.
   static const voidType = GenericType<Object>(TypeOid.voidType);
+
+  /// Must be a [IntRange]
+  static const int4range = GenericType<IntRange>(TypeOid.int4range);
+
+  /// Must be a [IntRange]
+  static const int8range = GenericType<IntRange>(TypeOid.int8range);
+
+  /// Must be a [DateRange]
+  static const daterange = GenericType<DateRange>(TypeOid.daterange);
+
+  /// Must be a [Range<Object>]
+  ///
+  /// Supported element types are the same as for [Type.numeric].
+  // static const numrange =
+  //     GenericType<ContinuousRange<String>>(TypeOid.numrange);
+
+  /// Must be a [Range<DateTime>]
+  static const tsrange = GenericType<DateTimeRange>(TypeOid.tsrange);
+
+  /// Must be a [Range<DateTime>]
+  static const tstzrange = GenericType<DateTimeRange>(TypeOid.tstzrange);
 
   /// The object ID of this data type.
   final int? oid;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -292,8 +292,8 @@ abstract class Type<T extends Object> {
   /// Must be a [Line]
   static const line = GenericType<Line>(TypeOid.line);
 
-  /// Must be a [Lseg]
-  static const lseg = GenericType<Lseg>(TypeOid.lseg);
+  /// Must be a [LineSegment]
+  static const lineSegment = GenericType<LineSegment>(TypeOid.lineSegment);
 
   /// Must be a [Box]
   static const box = GenericType<Box>(TypeOid.box);
@@ -346,7 +346,7 @@ abstract class Type<T extends Object> {
   static const int8range = GenericType<IntRange>(TypeOid.int8range);
 
   /// Must be a [DateRange]
-  static const daterange = GenericType<DateRange>(TypeOid.daterange);
+  static const dateRange = GenericType<DateRange>(TypeOid.dateRange);
 
   /// Must be a [Range<Object>]
   ///
@@ -355,10 +355,12 @@ abstract class Type<T extends Object> {
   //     GenericType<ContinuousRange<String>>(TypeOid.numrange);
 
   /// Must be a [Range<DateTime>]
-  static const tsrange = GenericType<DateTimeRange>(TypeOid.tsrange);
+  static const timestampRange =
+      GenericType<DateTimeRange>(TypeOid.timestampRange);
 
   /// Must be a [Range<DateTime>]
-  static const tstzrange = GenericType<DateTimeRange>(TypeOid.tstzrange);
+  static const timestampTzRange =
+      GenericType<DateTimeRange>(TypeOid.timestampTzRange);
 
   /// The object ID of this data type.
   final int? oid;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -170,7 +170,8 @@ class Time {
       DateTime.fromMicrosecondsSinceEpoch(microseconds, isUtc: true);
 
   /// The hour of the day, expressed as in a 25-hour clock `0...24`.
-  int get hour => microseconds == Duration.microsecondsPerDay ? 24 : 0;
+  int get hour =>
+      microseconds == Duration.microsecondsPerDay ? 24 : utcDateTime.hour;
 
   /// The minute `[0...59]`.
   int get minute => utcDateTime.minute;

--- a/lib/src/types/binary_codec.dart
+++ b/lib/src/types/binary_codec.dart
@@ -297,7 +297,7 @@ class PostgresBinaryEncoder {
           return bd.buffer.asUint8List();
         }
         throw FormatException(
-            'Invalid type for parameter value. Expected: Lseg Got: ${input.runtimeType}');
+            'Invalid type for parameter value. Expected: LineSegment Got: ${input.runtimeType}');
 
       case TypeOid.box:
         if (input is Box) {

--- a/lib/src/types/binary_codec.dart
+++ b/lib/src/types/binary_codec.dart
@@ -829,8 +829,6 @@ class PostgresBinaryDecoder {
         return range == null
             ? DateRange.empty()
             : DateRange(range.$1, range.$2, range.$3);
-      case TypeOid.numrange:
-        return _decodeRange(buffer, dinput, Type.numeric.oid!);
       case TypeOid.tsrange:
         final range =
             _decodeRange(buffer, dinput, Type.timestampWithoutTimezone.oid!);

--- a/lib/src/types/binary_codec.dart
+++ b/lib/src/types/binary_codec.dart
@@ -636,8 +636,8 @@ class PostgresBinaryEncoder {
     switch ((range.lower == null, range.upper == null)) {
       case (false, false):
         if (range.flag == 1) break;
-        _encodeRangeValue(range.lower!, encoding, elementTypeOid, buffer);
-        _encodeRangeValue(range.upper!, encoding, elementTypeOid, buffer);
+        _encodeRangeValue(range.lower, encoding, elementTypeOid, buffer);
+        _encodeRangeValue(range.upper, encoding, elementTypeOid, buffer);
         break;
       case (false, true) || (true, false):
         final value = range.lower ?? range.upper!;
@@ -649,10 +649,10 @@ class PostgresBinaryEncoder {
   }
 
   // Returns 4 length bytes + value bytes
-  _encodeRangeValue(
-      Object value, Encoding encoding, int elementTypeOid, BytesBuffer buffer) {
+  _encodeRangeValue<T>(
+      T value, Encoding encoding, int elementTypeOid, BytesBuffer buffer) {
     final encoder = PostgresBinaryEncoder(elementTypeOid);
-    final valueBytes = encoder.convert(value, encoding);
+    final valueBytes = encoder.convert(value as Object, encoding);
     final lengthBytes = ByteData(4)..setInt32(0, valueBytes.length);
     buffer.add(lengthBytes.buffer.asUint8List());
     buffer.add(valueBytes);

--- a/lib/src/types/binary_codec.dart
+++ b/lib/src/types/binary_codec.dart
@@ -151,8 +151,8 @@ class PostgresBinaryEncoder {
         {
           if (input is DateTime) {
             final bd = ByteData(8);
-            final diff = input.toUtc().difference(DateTime.utc(2000));
-            bd.setInt64(0, diff.inMicroseconds);
+            bd.setInt64(
+                0, input.toUtc().difference(DateTime.utc(2000)).inMicroseconds);
             return bd.buffer.asUint8List();
           }
           throw FormatException(
@@ -287,8 +287,8 @@ class PostgresBinaryEncoder {
         throw FormatException(
             'Invalid type for parameter value. Expected: Line Got: ${input.runtimeType}');
 
-      case TypeOid.lseg:
-        if (input is Lseg) {
+      case TypeOid.lineSegment:
+        if (input is LineSegment) {
           final bd = ByteData(32);
           bd.setFloat64(0, input.p1.latitude);
           bd.setFloat64(8, input.p1.longitude);
@@ -486,14 +486,14 @@ class PostgresBinaryEncoder {
         throw FormatException(
             'Invalid type for parameter value. Expected: IntRange Got: ${input.runtimeType}');
 
-      case TypeOid.daterange:
+      case TypeOid.dateRange:
         if (input is DateRange) {
           return _encodeRange(input, encoding, Type.date.oid!);
         }
         throw FormatException(
             'Invalid type for parameter value. Expected: DateRange Got: ${input.runtimeType}');
 
-      case TypeOid.tsrange:
+      case TypeOid.timestampRange:
         if (input is DateTimeRange) {
           return _encodeRange(
               input, encoding, Type.timestampWithoutTimezone.oid!);
@@ -501,7 +501,7 @@ class PostgresBinaryEncoder {
         throw FormatException(
             'Invalid type for parameter value. Expected: DateTimeRange Got: ${input.runtimeType}');
 
-      case TypeOid.tstzrange:
+      case TypeOid.timestampTzRange:
         if (input is DateTimeRange) {
           return _encodeRange(input, encoding, Type.timestampWithTimezone.oid!);
         }
@@ -642,9 +642,10 @@ class PostgresBinaryEncoder {
       case (false, true) || (true, false):
         final value = range.lower ?? range.upper!;
         _encodeRangeValue(value, encoding, elementTypeOid, buffer);
+        break;
       case (true, true):
+        break;
     }
-    // print(buffer.toBytes());
     return buffer.toBytes();
   }
 
@@ -755,8 +756,8 @@ class PostgresBinaryDecoder {
         return Line(
             buffer.getFloat64(0), buffer.getFloat64(8), buffer.getFloat64(16));
 
-      case TypeOid.lseg:
-        return Lseg(Point(buffer.getFloat64(0), buffer.getFloat64(8)),
+      case TypeOid.lineSegment:
+        return LineSegment(Point(buffer.getFloat64(0), buffer.getFloat64(8)),
             Point(buffer.getFloat64(16), buffer.getFloat64(24)));
 
       case TypeOid.box:
@@ -824,18 +825,18 @@ class PostgresBinaryDecoder {
         return range == null
             ? IntRange.empty()
             : IntRange(range.$1, range.$2, range.$3);
-      case TypeOid.daterange:
+      case TypeOid.dateRange:
         final range = _decodeRange(buffer, dinput, Type.date.oid!);
         return range == null
             ? DateRange.empty()
             : DateRange(range.$1, range.$2, range.$3);
-      case TypeOid.tsrange:
+      case TypeOid.timestampRange:
         final range =
             _decodeRange(buffer, dinput, Type.timestampWithoutTimezone.oid!);
         return range == null
             ? DateTimeRange.empty()
             : DateTimeRange(range.$1, range.$2, range.$3);
-      case TypeOid.tstzrange:
+      case TypeOid.timestampTzRange:
         final range =
             _decodeRange(buffer, dinput, Type.timestampWithTimezone.oid!);
         return range == null

--- a/lib/src/types/geo_types.dart
+++ b/lib/src/types/geo_types.dart
@@ -1,0 +1,186 @@
+import 'dart:core';
+
+import 'package:meta/meta.dart';
+
+/// Describes PostgreSQL's geometric type: `point`.
+@immutable
+class Point {
+  /// also referred as `x`
+  final double latitude;
+
+  /// also referred as `y`
+  final double longitude;
+
+  const Point(this.latitude, this.longitude);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Point &&
+          runtimeType == other.runtimeType &&
+          latitude == other.latitude &&
+          longitude == other.longitude;
+
+  @override
+  int get hashCode => Object.hash(latitude, longitude);
+
+  @override
+  String toString() => 'Point($latitude,$longitude)';
+}
+
+/// Describes PostgreSQL's geometric type: `line`.
+///
+/// A line as defined by the linear equation _ax + by + c = 0_.
+///
+/// See https://www.postgresql.org/docs/current/datatype-geometric.html#DATATYPE-LINE
+///
+@immutable
+class Line {
+  final double a, b, c;
+
+  Line(this.a, this.b, this.c) {
+    if (a == 0 && b == 0) {
+      throw ArgumentError('Line: a and b cannot both be zero');
+    }
+  }
+
+  @override
+  String toString() => 'Line($a,$b,$c)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Line &&
+          runtimeType == other.runtimeType &&
+          a == other.a &&
+          b == other.b &&
+          c == other.c;
+
+  @override
+  int get hashCode => Object.hash(a, b, c);
+}
+
+/// Describes PostgreSQL's geometric type: `lseg`.
+@immutable
+class Lseg {
+  late final Point p1, p2;
+
+  Lseg(this.p1, this.p2);
+
+  @override
+  String toString() => 'Lseg($p1,$p2)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Lseg &&
+          runtimeType == other.runtimeType &&
+          p1 == other.p1 &&
+          p2 == other.p2;
+
+  @override
+  int get hashCode => Object.hash(p1, p2);
+}
+
+/// Describes PostgreSQL's geometric type: `box`.
+@immutable
+class Box {
+  late final Point p1, p2;
+
+  Box(this.p1, this.p2);
+
+  @override
+  String toString() => 'Box($p1,$p2)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Box &&
+          runtimeType == other.runtimeType &&
+          (p1 == other.p1 && p2 == other.p2 ||
+              p1 == other.p2 && p2 == other.p1);
+
+  @override
+  int get hashCode => Object.hash(p1, p2);
+}
+
+/// Describes PostgreSQL's geometric type: `polygon`.
+@immutable
+class Polygon {
+  late final List<Point> _points;
+
+  List<Point> get points => _points;
+
+  Polygon(Iterable<Point> points) {
+    if (points.isEmpty) {
+      throw ArgumentError('$runtimeType: at least one point required');
+    }
+    _points = List.unmodifiable(points);
+  }
+
+  @override
+  String toString() => 'Polygon(${points.map((e) => e.toString()).join(',')})';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Polygon &&
+          runtimeType == other.runtimeType &&
+          _allPointsAreEqual(other.points);
+
+  bool _allPointsAreEqual(List<Point> otherPoints) {
+    if (points.length != otherPoints.length) return false;
+    for (int i = 0; i < points.length; i++) {
+      if (points[i] != otherPoints[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAll(points);
+}
+
+/// Describes PostgreSQL's geometric type: `path`.
+class Path extends Polygon {
+  final bool open;
+
+  Path(super.points, this.open);
+
+  @override
+  String toString() =>
+      'Path(${open ? 'open' : 'closed'},${points.map((e) => e.toString()).join(',')})';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Path &&
+          runtimeType == other.runtimeType &&
+          open == other.open &&
+          _allPointsAreEqual(other.points);
+
+  @override
+  int get hashCode => Object.hashAll([...points, open]);
+}
+
+class Circle {
+  final Point center;
+  final double radius;
+
+  Circle(this.center, this.radius) {
+    if (radius < 0) throw ArgumentError('Circle: radius must not negative');
+  }
+
+  @override
+  String toString() => 'Circle($center,$radius)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Circle &&
+          runtimeType == other.runtimeType &&
+          radius == other.radius &&
+          center == other.center;
+
+  @override
+  int get hashCode => Object.hash(center, radius);
+}

--- a/lib/src/types/geo_types.dart
+++ b/lib/src/types/geo_types.dart
@@ -62,18 +62,18 @@ class Line {
 
 /// Describes PostgreSQL's geometric type: `lseg`.
 @immutable
-class Lseg {
+class LineSegment {
   late final Point p1, p2;
 
-  Lseg(this.p1, this.p2);
+  LineSegment(this.p1, this.p2);
 
   @override
-  String toString() => 'Lseg($p1,$p2)';
+  String toString() => 'LineSegment($p1,$p2)';
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is Lseg &&
+      other is LineSegment &&
           runtimeType == other.runtimeType &&
           p1 == other.p1 &&
           p2 == other.p2;

--- a/lib/src/types/range_types.dart
+++ b/lib/src/types/range_types.dart
@@ -196,7 +196,7 @@ class DateRange extends DiscreteRange<DateTime> {
     if (dt == null) return null;
     final days = dt.microsecondsSinceEpoch ~/ Duration.microsecondsPerDay;
     final microseconds = days * Duration.microsecondsPerDay;
-    return DateTime.fromMicrosecondsSinceEpoch(microseconds);
+    return DateTime.fromMicrosecondsSinceEpoch(microseconds, isUtc: true);
   }
 
   @override

--- a/lib/src/types/range_types.dart
+++ b/lib/src/types/range_types.dart
@@ -21,35 +21,40 @@ class Bounds {
 
   Bounds(this.lower, this.upper);
 
+  ///  Construct a [Bounds] instance from a PostgreSQL [flag] value.
+  ///
+  ///
+  ///  PostgreSQL stores a flag byte that determines range bounds and
+  ///  whether a range is empty. The default lower and upper bounds are `exclusive`.
+  ///
+  ///  A range's flags byte contains these bits:
+  ///  - #define RANGE_EMPTY         0x01    (range is empty)
+  ///  - #define RANGE_LB_INC        0x02    (lower bound is inclusive)
+  ///  - #define RANGE_UB_INC        0x04    (upper bound is inclusive)
+  ///  - #define RANGE_LB_INF        0x08    (lower bound is -infinity)
+  ///  - #define RANGE_UB_INF        0x10    (upper bound is +infinity)
+  ///
+  ///  - #define RANGE_LB_NULL       0x20    (lower bound is null (NOT USED))
+  ///  - #define RANGE_UB_NULL       0x40    (upper bound is null (NOT USED))
+  ///  - #define RANGE_CONTAIN_EMPTY 0x80    (marks a GiST internal-page entry whose subtree contains some empty ranges)
+  ///
+  /// See https://www.npgsql.org/doc/dev/type-representations.html
   Bounds.fromFlag(int flag) {
     switch (flag) {
-      case 0 || 1:
+      case 0 || 1 || 8 || 16 || 24:
         lower = Bound.exclusive;
         upper = Bound.exclusive;
-      case 2:
+      case 2 || 18:
         lower = Bound.inclusive;
         upper = Bound.exclusive;
-      case 4:
+      case 4 || 12:
         lower = Bound.exclusive;
         upper = Bound.inclusive;
       case 6:
         lower = Bound.inclusive;
         upper = Bound.inclusive;
-      case 8:
-        lower = Bound.exclusive;
-        upper = Bound.exclusive;
-      case 12:
-        lower = Bound.exclusive;
-        upper = Bound.inclusive;
-      case 16:
-        lower = Bound.exclusive;
-        upper = Bound.exclusive;
-      case 18:
-        lower = Bound.inclusive;
-        upper = Bound.exclusive;
-      case 24:
-        lower = Bound.exclusive;
-        upper = Bound.exclusive;
+      default:
+        throw UnimplementedError('Range flag $flag not implemented');
     }
   }
 

--- a/lib/src/types/range_types.dart
+++ b/lib/src/types/range_types.dart
@@ -1,0 +1,258 @@
+import 'package:meta/meta.dart';
+
+/// Describes PostgreSQL range bound state
+///
+/// https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-INCLUSIVITY
+enum Bound {
+  /// Equivalent to '(' or ')'
+  exclusive,
+
+  /// Equivalent to '[' or ']'
+  inclusive,
+}
+
+/// Describes the bounds of PostgreSQL range types.
+///
+/// https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-INCLUSIVITY
+@immutable
+class Bounds {
+  late final Bound lower;
+  late final Bound upper;
+
+  Bounds(this.lower, this.upper);
+
+  Bounds.fromFlag(int flag) {
+    switch (flag) {
+      case 0 || 1:
+        lower = Bound.exclusive;
+        upper = Bound.exclusive;
+      case 2:
+        lower = Bound.inclusive;
+        upper = Bound.exclusive;
+      case 4:
+        lower = Bound.exclusive;
+        upper = Bound.inclusive;
+      case 6:
+        lower = Bound.inclusive;
+        upper = Bound.inclusive;
+      case 8:
+        lower = Bound.exclusive;
+        upper = Bound.exclusive;
+      case 12:
+        lower = Bound.exclusive;
+        upper = Bound.inclusive;
+      case 16:
+        lower = Bound.exclusive;
+        upper = Bound.exclusive;
+      case 18:
+        lower = Bound.inclusive;
+        upper = Bound.exclusive;
+      case 24:
+        lower = Bound.exclusive;
+        upper = Bound.exclusive;
+    }
+  }
+
+  int get _lowerFlag {
+    switch (lower) {
+      case Bound.exclusive:
+        return 0;
+      case Bound.inclusive:
+        return 2;
+    }
+  }
+
+  int get _upperFlag {
+    switch (upper) {
+      case Bound.exclusive:
+        return 0;
+      case Bound.inclusive:
+        return 4;
+    }
+  }
+
+  @override
+  String toString() => 'Bounds(${lower.name},${upper.name})';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Bounds &&
+          runtimeType == other.runtimeType &&
+          lower == other.lower &&
+          upper == other.upper;
+
+  @override
+  int get hashCode => _lowerFlag + _upperFlag;
+}
+
+abstract interface class Range<T> {
+  late final T? _lower;
+  late final T? _upper;
+  late final Bounds _bounds;
+
+  Bounds get bounds => _bounds;
+
+  T? get lower => _lower;
+
+  T? get upper => _upper;
+
+  int get flag {
+    switch ((lower == null, upper == null)) {
+      case (true, true):
+        return 24;
+      case (true, false):
+        return 8 + bounds._upperFlag;
+      case (false, true):
+        return 16 + bounds._lowerFlag;
+      case (false, false):
+        return lower == upper ? 1 : bounds._lowerFlag + bounds._upperFlag;
+    }
+  }
+
+  _throwIfLowerGreaterThanUpper(T? lower, T? upper) {
+    if (_lowerGreaterThanUpper(lower, upper)) {
+      throw ArgumentError(
+          'Range: lower bound must be less than or equal to upper bound');
+    }
+  }
+
+  bool _lowerGreaterThanUpper(T? lower, T? upper) =>
+      lower != null &&
+      upper != null &&
+      lower is Comparable &&
+      lower.compareTo(upper as Comparable) > 0;
+
+  @override
+  String toString() => '$runtimeType($lower,$upper,$bounds)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is Range<T> && runtimeType == other.runtimeType) {
+      return flag == 1
+          ? flag == other.flag
+          : flag == other.flag && lower == other.lower && upper == other.upper;
+    }
+    return false;
+  }
+
+  @override
+  int get hashCode => flag == 1 ? flag : Object.hash(lower, upper, flag);
+}
+
+abstract interface class DiscreteRange<T> extends Range<T> {
+  DiscreteRange(T? lower, T? upper, Bounds bounds) {
+    _throwIfLowerGreaterThanUpper(lower, upper);
+    final (l, lBound) = _canonicalizeLower(lower, bounds.lower);
+    final (u, uBound) = _canonicalizeUpper(upper, bounds.upper);
+    _lower = _lowerGreaterThanUpper(l, u) ? lower : l;
+    _upper = u;
+    _bounds = Bounds(lBound, uBound);
+  }
+
+  (T?, Bound) _canonicalizeLower(T? lower, Bound bound);
+
+  (T?, Bound) _canonicalizeUpper(T? upper, Bound bound);
+}
+
+/// Describes PostgreSQL's builtin `int4range` and `int8range`
+///
+/// https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-BUILTIN
+class IntRange extends DiscreteRange<int> {
+  IntRange(super.lower, super.upper, super.bounds);
+
+  /// Construct an empty [IntRange]
+  IntRange.empty() : super(0, 0, Bounds(Bound.inclusive, Bound.exclusive));
+
+  @override
+  (int?, Bound) _canonicalizeLower(int? lower, Bound bound) {
+    if (lower == null) return (null, Bound.exclusive);
+    if (bound == Bound.exclusive) return (lower + 1, Bound.inclusive);
+    return (lower, bound);
+  }
+
+  @override
+  (int?, Bound) _canonicalizeUpper(int? upper, Bound bound) {
+    if (upper == null) return (null, Bound.exclusive);
+    if (bound == Bound.inclusive) return (upper + 1, Bound.exclusive);
+    return (upper, bound);
+  }
+}
+
+final _z0 = DateTime.utc(1970);
+
+/// Describes PostgreSQL's builtin `daterange`
+///
+/// https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-BUILTIN
+class DateRange extends DiscreteRange<DateTime> {
+  DateRange(super.lower, super.upper, super.bounds);
+
+  /// Construct an empty [DateRange]
+  DateRange.empty() : super(_z0, _z0, Bounds(Bound.inclusive, Bound.exclusive));
+
+  /// Remove hours, minutes, seconds, milliseconds and microseconds from [DateTime]
+  DateTime? _removeTime(DateTime? dt) {
+    if (dt == null) return null;
+    final days = dt.microsecondsSinceEpoch ~/ Duration.microsecondsPerDay;
+    final microseconds = days * Duration.microsecondsPerDay;
+    return DateTime.fromMicrosecondsSinceEpoch(microseconds);
+  }
+
+  @override
+  (DateTime?, Bound) _canonicalizeLower(DateTime? lower, Bound bound) {
+    if (lower == null) return (null, Bound.exclusive);
+    if (bound == Bound.exclusive) {
+      return (_removeTime(lower.add(Duration(days: 1))), Bound.inclusive);
+    }
+    return (_removeTime(lower), bound);
+  }
+
+  @override
+  (DateTime?, Bound) _canonicalizeUpper(DateTime? upper, Bound bound) {
+    if (upper == null) return (null, Bound.exclusive);
+    if (bound == Bound.inclusive) {
+      return (_removeTime(upper.add(Duration(days: 1))), Bound.exclusive);
+    }
+    return (_removeTime(upper), bound);
+  }
+}
+
+/// Describes PostgreSQL's continuous builtin range types:
+/// - `numrange`
+/// - `tsrange`
+/// - `tstzrange`
+///
+/// https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-BUILTIN
+interface class ContinuousRange<T> extends Range<T> {
+  ContinuousRange(T? lower, T? upper, Bounds bounds) {
+    _throwIfLowerGreaterThanUpper(lower, upper);
+    _lower = lower;
+    _upper = upper;
+    _bounds = _canonicalizeNullBounds(bounds);
+  }
+
+  /// Infinity (or `null`-valued) bounds are always stored as [Bound.exclusive]
+  ///
+  /// https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-INFINITE
+  Bounds _canonicalizeNullBounds(Bounds bounds) {
+    switch ((lower == null, upper == null)) {
+      case (true, true):
+        return Bounds(Bound.exclusive, Bound.exclusive);
+      case (false, true):
+        return Bounds(bounds.lower, Bound.exclusive);
+      case (true, false):
+        return Bounds(Bound.exclusive, bounds.upper);
+      case (false, false):
+        return bounds;
+    }
+  }
+}
+
+class DateTimeRange extends ContinuousRange<DateTime> {
+  DateTimeRange(super.lower, super.upper, super.bounds);
+
+  /// Construct an empty [TsRange]
+  DateTimeRange.empty()
+      : super(_z0, _z0, Bounds(Bound.inclusive, Bound.exclusive));
+}

--- a/lib/src/types/text_codec.dart
+++ b/lib/src/types/text_codec.dart
@@ -4,6 +4,7 @@ import 'package:postgres/src/types/generic_type.dart';
 
 import '../exceptions.dart';
 import '../types.dart';
+import 'geo_types.dart';
 import 'type_registry.dart';
 
 class PostgresTextEncoder {

--- a/lib/src/types/type_registry.dart
+++ b/lib/src/types/type_registry.dart
@@ -7,7 +7,6 @@ import 'package:postgres/src/exceptions.dart';
 import 'package:postgres/src/types/text_codec.dart';
 
 import '../types.dart';
-
 import 'generic_type.dart';
 
 typedef TypeEncoderFn = EncodeOutput Function(EncodeInput input);
@@ -19,27 +18,40 @@ class TypeOid {
   static const bigIntegerArray = 1016;
   static const boolean = 16;
   static const booleanArray = 1000;
+  static const box = 603;
   static const byteArray = 17;
   static const character = 1042;
+  static const circle = 718;
   static const date = 1082;
+  static const daterange = 3912;
   static const double = 701;
   static const doubleArray = 1022;
+  static const int4range = 3904;
+  static const int8range = 3926;
   static const integer = 23;
   static const integerArray = 1007;
   static const interval = 1186;
   static const json = 114;
   static const jsonb = 3802;
   static const jsonbArray = 3807;
+  static const line = 628;
+  static const lseg = 601;
   static const name = 19;
   static const numeric = 1700;
+  static const numrange = 3906;
+  static const path = 602;
   static const point = 600;
+  static const polygon = 604;
   static const real = 700;
   static const regtype = 2206;
   static const smallInteger = 21;
   static const text = 25;
   static const textArray = 1009;
+  static const time = 1083;
   static const timestampWithoutTimezone = 1114;
   static const timestampWithTimezone = 1184;
+  static const tsrange = 3908;
+  static const tstzrange = 3910;
   static const uuid = 2950;
   static const varChar = 1043;
   static const varCharArray = 1015;
@@ -59,6 +71,7 @@ final _builtInTypes = <Type>{
   Type.double,
   Type.boolean,
   Type.voidType,
+  Type.time,
   Type.timestampWithTimezone,
   Type.timestampWithoutTimezone,
   Type.interval,
@@ -69,6 +82,12 @@ final _builtInTypes = <Type>{
   Type.jsonb,
   Type.uuid,
   Type.point,
+  Type.line,
+  Type.lseg,
+  Type.box,
+  Type.polygon,
+  Type.path,
+  Type.circle,
   Type.booleanArray,
   Type.integerArray,
   Type.bigIntegerArray,
@@ -77,6 +96,12 @@ final _builtInTypes = <Type>{
   Type.varCharArray,
   Type.jsonbArray,
   Type.regtype,
+  Type.int4range,
+  Type.int8range,
+  Type.daterange,
+  // Type.numrange,
+  Type.tsrange,
+  Type.tstzrange,
 };
 
 final _builtInTypeNames = <String, Type>{
@@ -87,28 +112,41 @@ final _builtInTypeNames = <String, Type>{
   'char': Type.character,
   'character': Type.character,
   'date': Type.date,
+  'daterange': Type.daterange,
   'double precision': Type.double,
   'float4': Type.real,
   'float8': Type.double,
   'int': Type.integer,
   'int2': Type.smallInteger,
   'int4': Type.integer,
+  'int4range': Type.int4range,
   'int8': Type.bigInteger,
+  'int8range': Type.int8range,
   'integer': Type.integer,
   'interval': Type.interval,
   'json': Type.json,
   'jsonb': Type.jsonb,
   'name': Type.name,
   'numeric': Type.numeric,
+  // 'numrange': Type.numrange,
   'point': Type.point,
+  'line': Type.line,
+  'lseg': Type.lseg,
+  'box': Type.box,
+  'polygon': Type.polygon,
+  'path': Type.path,
+  'circle': Type.circle,
   'read': Type.real,
   'regtype': Type.regtype,
   'serial4': Type.serial,
   'serial8': Type.bigSerial,
   'smallint': Type.smallInteger,
   'text': Type.text,
+  'time': Type.time,
   'timestamp': Type.timestampWithoutTimezone,
   'timestamptz': Type.timestampWithTimezone,
+  'tsrange': Type.tsrange,
+  'tstzrange': Type.tstzrange,
   'varchar': Type.varChar,
   'uuid': Type.uuid,
   '_bool': Type.booleanArray,

--- a/lib/src/types/type_registry.dart
+++ b/lib/src/types/type_registry.dart
@@ -23,7 +23,7 @@ class TypeOid {
   static const character = 1042;
   static const circle = 718;
   static const date = 1082;
-  static const daterange = 3912;
+  static const dateRange = 3912;
   static const double = 701;
   static const doubleArray = 1022;
   static const int4range = 3904;
@@ -35,7 +35,7 @@ class TypeOid {
   static const jsonb = 3802;
   static const jsonbArray = 3807;
   static const line = 628;
-  static const lseg = 601;
+  static const lineSegment = 601;
   static const name = 19;
   static const numeric = 1700;
   static const numrange = 3906;
@@ -50,8 +50,8 @@ class TypeOid {
   static const time = 1083;
   static const timestampWithoutTimezone = 1114;
   static const timestampWithTimezone = 1184;
-  static const tsrange = 3908;
-  static const tstzrange = 3910;
+  static const timestampRange = 3908;
+  static const timestampTzRange = 3910;
   static const uuid = 2950;
   static const varChar = 1043;
   static const varCharArray = 1015;
@@ -83,7 +83,7 @@ final _builtInTypes = <Type>{
   Type.uuid,
   Type.point,
   Type.line,
-  Type.lseg,
+  Type.lineSegment,
   Type.box,
   Type.polygon,
   Type.path,
@@ -98,10 +98,10 @@ final _builtInTypes = <Type>{
   Type.regtype,
   Type.int4range,
   Type.int8range,
-  Type.daterange,
+  Type.dateRange,
   // Type.numrange,
-  Type.tsrange,
-  Type.tstzrange,
+  Type.timestampRange,
+  Type.timestampTzRange,
 };
 
 final _builtInTypeNames = <String, Type>{
@@ -112,7 +112,7 @@ final _builtInTypeNames = <String, Type>{
   'char': Type.character,
   'character': Type.character,
   'date': Type.date,
-  'daterange': Type.daterange,
+  'daterange': Type.dateRange,
   'double precision': Type.double,
   'float4': Type.real,
   'float8': Type.double,
@@ -131,7 +131,7 @@ final _builtInTypeNames = <String, Type>{
   // 'numrange': Type.numrange,
   'point': Type.point,
   'line': Type.line,
-  'lseg': Type.lseg,
+  'lseg': Type.lineSegment,
   'box': Type.box,
   'polygon': Type.polygon,
   'path': Type.path,
@@ -145,8 +145,8 @@ final _builtInTypeNames = <String, Type>{
   'time': Type.time,
   'timestamp': Type.timestampWithoutTimezone,
   'timestamptz': Type.timestampWithTimezone,
-  'tsrange': Type.tsrange,
-  'tstzrange': Type.tstzrange,
+  'tsrange': Type.timestampRange,
+  'tstzrange': Type.timestampTzRange,
   'varchar': Type.varChar,
   'uuid': Type.uuid,
   '_bool': Type.booleanArray,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol and connection pooling.
-version: 3.0.8
+version: 3.0.9
 homepage: https://github.com/isoos/postgresql-dart
 topics:
   - sql

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -503,6 +503,233 @@ void main() {
       await conn.execute(Sql.named('SELECT TO_TIMESTAMP(@ts:int8 / 1000)'),
           parameters: {'ts': 1640556171599});
     });
+
+    test('time', () async {
+      await expectReversible(
+        'time',
+        [
+          null,
+          Time(16, 0, 44, 0, 888),
+          Time.fromMicroseconds(57644000888),
+          Time(0, 0, 0, 0, 86400000000),
+          Time(0),
+        ],
+        expectedDartType: 'Time',
+      );
+    });
+
+    test('line', () async {
+      await expectReversible(
+        'line',
+        [
+          null,
+          Line(1, 2, 3),
+          Line(.0002, .000001, 100000),
+        ],
+        expectedDartType: 'Line',
+      );
+    });
+
+    test('lseg', () async {
+      await expectReversible(
+        'lseg',
+        [
+          null,
+          Lseg(Point(1, 2), Point(3, 4)),
+          Lseg(Point(1, 2), Point(1, 2)),
+        ],
+        expectedDartType: 'Lseg',
+      );
+    });
+
+    test('box', () async {
+      await expectReversible(
+        'box',
+        [
+          null,
+          Box(Point(1, 2), Point(3, 4)),
+          Box(Point(1.0, 2), Point(1, 2)),
+          Box(Point(3, 4), Point(-12, -12312.123412)),
+        ],
+        expectedDartType: 'Box',
+      );
+    });
+
+    test('polygon', () async {
+      await expectReversible(
+        'polygon',
+        [
+          null,
+          Polygon([Point(0, 0)]),
+          Polygon([Point(1, 2), Point(3, 4), Point(5, 6), Point(7, 8.2)]),
+          Polygon([Point(1, 2), Point(3, 4), Point(5, 6), Point(-7, -8.2)]),
+        ],
+        expectedDartType: 'Polygon',
+      );
+    });
+
+    test('path', () async {
+      await expectReversible(
+        'path',
+        [
+          null,
+          Path([Point(0, 0)], false),
+          Path([Point(1, 2), Point(3, 4), Point(5, 6), Point(7, 8.2)], true),
+          Path([Point(1, 2), Point(3, 4), Point(5, 6), Point(-7, -8.2)], true),
+        ],
+        expectedDartType: 'Path',
+      );
+    });
+
+    test('circle', () async {
+      await expectReversible(
+        'circle',
+        [
+          null,
+          Circle(Point(0, 0), 0),
+          Circle(Point(-1, 1), 1.234),
+        ],
+        expectedDartType: 'Circle',
+      );
+    });
+
+    test('int4range', () async {
+      await expectReversible(
+        'int4range',
+        [
+          null,
+          // normal ranges
+          IntRange(4, 4, Bounds(Bound.inclusive, Bound.inclusive)),
+          IntRange(4, 5, Bounds(Bound.inclusive, Bound.inclusive)),
+          IntRange(4, 6, Bounds(Bound.exclusive, Bound.exclusive)),
+          // partially unbounded ranges
+          IntRange(null, 4, Bounds(Bound.inclusive, Bound.exclusive)),
+          IntRange(4, null, Bounds(Bound.inclusive, Bound.exclusive)),
+          IntRange(null, 4, Bounds(Bound.exclusive, Bound.inclusive)),
+          IntRange(4, null, Bounds(Bound.exclusive, Bound.inclusive)),
+          // unbounded ranges
+          IntRange(null, null, Bounds(Bound.exclusive, Bound.inclusive)),
+          IntRange(null, null, Bounds(Bound.exclusive, Bound.exclusive)),
+          IntRange(null, null, Bounds(Bound.inclusive, Bound.exclusive)),
+          IntRange(null, null, Bounds(Bound.inclusive, Bound.inclusive)),
+          // empty ranges
+          IntRange(4, 4, Bounds(Bound.exclusive, Bound.exclusive)),
+          IntRange(4, 4, Bounds(Bound.inclusive, Bound.exclusive)),
+          IntRange(4, 4, Bounds(Bound.exclusive, Bound.inclusive)),
+          IntRange(4, 5, Bounds(Bound.exclusive, Bound.exclusive)),
+        ],
+        expectedDartType: 'IntRange',
+      );
+    });
+
+    test('int8range', () async {
+      await expectReversible(
+        'int8range',
+        [
+          null,
+          // normal ranges
+          IntRange(4, 4, Bounds(Bound.inclusive, Bound.inclusive)),
+          IntRange(4, 5, Bounds(Bound.inclusive, Bound.inclusive)),
+          IntRange(4, 6, Bounds(Bound.exclusive, Bound.exclusive)),
+          // partially unbounded ranges
+          IntRange(null, 4, Bounds(Bound.inclusive, Bound.exclusive)),
+          IntRange(4, null, Bounds(Bound.inclusive, Bound.exclusive)),
+          IntRange(null, 4, Bounds(Bound.exclusive, Bound.inclusive)),
+          IntRange(4, null, Bounds(Bound.exclusive, Bound.inclusive)),
+          // unbounded ranges
+          IntRange(null, null, Bounds(Bound.exclusive, Bound.inclusive)),
+          IntRange(null, null, Bounds(Bound.exclusive, Bound.exclusive)),
+          IntRange(null, null, Bounds(Bound.inclusive, Bound.exclusive)),
+          IntRange(null, null, Bounds(Bound.inclusive, Bound.inclusive)),
+          // empty ranges
+          IntRange(4, 4, Bounds(Bound.exclusive, Bound.exclusive)),
+          IntRange(4, 4, Bounds(Bound.inclusive, Bound.exclusive)),
+          IntRange(4, 4, Bounds(Bound.exclusive, Bound.inclusive)),
+          IntRange(4, 5, Bounds(Bound.exclusive, Bound.exclusive)),
+        ],
+        expectedDartType: 'IntRange',
+      );
+    });
+
+    test('daterange', () async {
+      await expectReversible(
+        'daterange',
+        [
+          null,
+          // normal ranges
+          DateRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4, 12),
+              Bounds(Bound.inclusive, Bound.inclusive)),
+          DateRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 5),
+              Bounds(Bound.inclusive, Bound.inclusive)),
+          DateRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 6),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+          // partially unbounded ranges
+          DateRange(null, DateTime.utc(2000, 4, 4),
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateRange(DateTime.utc(2000, 4, 4), null,
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateRange(null, DateTime.utc(2000, 4, 4),
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          DateRange(DateTime.utc(2000, 4, 4), null,
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          // unbounded ranges
+          DateRange(null, null, Bounds(Bound.exclusive, Bound.inclusive)),
+          DateRange(null, null, Bounds(Bound.exclusive, Bound.exclusive)),
+          DateRange(null, null, Bounds(Bound.inclusive, Bound.exclusive)),
+          DateRange(null, null, Bounds(Bound.inclusive, Bound.inclusive)),
+          // empty ranges
+          DateRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4, 12),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+          DateRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4),
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4),
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          DateRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 5),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+        ],
+        expectedDartType: 'DateRange',
+      );
+    });
+
+    test('tsrange', () async {
+      await expectReversible(
+        'tsrange',
+        [
+          null,
+          // normal ranges
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4, 12),
+              Bounds(Bound.inclusive, Bound.inclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 5),
+              Bounds(Bound.inclusive, Bound.inclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 6),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+          // partially unbounded ranges
+          DateTimeRange(null, DateTime.utc(2000, 4, 4),
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), null,
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateTimeRange(null, DateTime.utc(2000, 4, 4),
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), null,
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          // unbounded ranges
+          DateTimeRange(null, null, Bounds(Bound.exclusive, Bound.inclusive)),
+          DateTimeRange(null, null, Bounds(Bound.exclusive, Bound.exclusive)),
+          DateTimeRange(null, null, Bounds(Bound.inclusive, Bound.exclusive)),
+          DateTimeRange(null, null, Bounds(Bound.inclusive, Bound.inclusive)),
+          // empty ranges
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4),
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4),
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 5),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+        ],
+        expectedDartType: 'DateTimeRange',
+      );
+    });
   });
 
   group('Text encoders', () {

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -538,7 +538,7 @@ void main() {
           LineSegment(Point(1, 2), Point(3, 4)),
           LineSegment(Point(1, 2), Point(1, 2)),
         ],
-        expectedDartType: 'Lseg',
+        expectedDartType: 'LineSegment',
       );
     });
 
@@ -694,6 +694,46 @@ void main() {
     test('tsrange', () async {
       await expectReversible(
         'tsrange',
+        [
+          null,
+          // normal ranges
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4, 12),
+              Bounds(Bound.inclusive, Bound.inclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 5),
+              Bounds(Bound.inclusive, Bound.inclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 6),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+          // partially unbounded ranges
+          DateTimeRange(null, DateTime.utc(2000, 4, 4),
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), null,
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateTimeRange(null, DateTime.utc(2000, 4, 4),
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), null,
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          // unbounded ranges
+          DateTimeRange(null, null, Bounds(Bound.exclusive, Bound.inclusive)),
+          DateTimeRange(null, null, Bounds(Bound.exclusive, Bound.exclusive)),
+          DateTimeRange(null, null, Bounds(Bound.inclusive, Bound.exclusive)),
+          DateTimeRange(null, null, Bounds(Bound.inclusive, Bound.inclusive)),
+          // empty ranges
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4),
+              Bounds(Bound.inclusive, Bound.exclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 4),
+              Bounds(Bound.exclusive, Bound.inclusive)),
+          DateTimeRange(DateTime.utc(2000, 4, 4), DateTime.utc(2000, 4, 5),
+              Bounds(Bound.exclusive, Bound.exclusive)),
+        ],
+        expectedDartType: 'DateTimeRange',
+      );
+    });
+
+    test('tstzrange', () async {
+      await expectReversible(
+        'tstzrange',
         [
           null,
           // normal ranges

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -535,8 +535,8 @@ void main() {
         'lseg',
         [
           null,
-          Lseg(Point(1, 2), Point(3, 4)),
-          Lseg(Point(1, 2), Point(1, 2)),
+          LineSegment(Point(1, 2), Point(3, 4)),
+          LineSegment(Point(1, 2), Point(1, 2)),
         ],
         expectedDartType: 'Lseg',
       );


### PR DESCRIPTION
I added some builtin types as discussed in issue #293.

This is the first time I contribute to a project on Github, so I'm more than happy to fix any issues you might see with pull request.

Once is merged, I would add `numrange`, but I wanted to ask if it wouldn't be better to change the current `numeric` type from `GenericType<Object>(TypeOid.numeric)` that accepts `int`, `double` and `String` to `GenericType<Decimal>(TypeOid.numeric)` using the decimal library (https://pub.dev/packages/decimal).