### PR TITLE
Allow explicit null representation in parameters

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -411,7 +411,15 @@ class TypedValue<T extends Object> {
   final Type<T> type;
   final T? value;
 
-  TypedValue(this.type, this.value);
+  /// Whether this value is deliberately describing a `NULL` value in SQL.
+  ///
+  /// For some types, in particular `json` and `jsonb`, the `null` value in Dart
+  /// can be mapped to a non-null SQL value (a textual or binary representation
+  /// of the `null` value in JSON, respectively).
+  final bool isSqlNull;
+
+  TypedValue(this.type, this.value, {bool? isSqlNull})
+      : isSqlNull = isSqlNull ?? (value == null);
 
   @override
   int get hashCode => Object.hash(type, value);

--- a/lib/src/types/binary_codec.dart
+++ b/lib/src/types/binary_codec.dart
@@ -52,7 +52,7 @@ class PostgresBinaryEncoder {
 
   const PostgresBinaryEncoder(this._typeOid);
 
-  Uint8List convert(Object input, Encoding encoding) {
+  Uint8List convert(Object? input, Encoding encoding) {
     switch (_typeOid) {
       case TypeOid.voidType:
         throw ArgumentError('Cannot encode `$input` into oid($_typeOid).');
@@ -192,7 +192,7 @@ class PostgresBinaryEncoder {
 
       case TypeOid.numeric:
         {
-          Object source = input;
+          Object? source = input;
 
           if (source is double || source is int) {
             source = input.toString();

--- a/lib/src/types/generic_type.dart
+++ b/lib/src/types/generic_type.dart
@@ -21,7 +21,7 @@ class EncodeOutput {
   bool get isBinary => bytes != null;
 }
 
-class EncodeInput<T extends Object> {
+class EncodeInput<T> {
   final T value;
   final Encoding encoding;
 
@@ -61,7 +61,7 @@ class GenericType<T extends Object> extends Type<T> {
 }
 
 extension GenericTypeExt<T extends Object> on GenericType<T> {
-  EncodeOutput encode(EncodeInput input) {
+  EncodeOutput encode(EncodeInput<T?> input) {
     if (oid != null && oid! > 0) {
       final encoder = PostgresBinaryEncoder(oid!);
       final bytes = encoder.convert(input.value, input.encoding);

--- a/lib/src/types/text_codec.dart
+++ b/lib/src/types/text_codec.dart
@@ -10,7 +10,7 @@ import 'type_registry.dart';
 class PostgresTextEncoder {
   const PostgresTextEncoder();
 
-  String convert(Object input, {bool escapeStrings = true}) {
+  String convert(Object? input, {bool escapeStrings = true}) {
     final value = tryConvert(input, escapeStrings: escapeStrings);
     if (value != null) {
       return value;
@@ -18,7 +18,7 @@ class PostgresTextEncoder {
     throw PgException("Could not infer type of value '$input'.");
   }
 
-  String? tryConvert(Object input, {bool escapeStrings = false}) {
+  String? tryConvert(Object? input, {bool escapeStrings = false}) {
     if (input is int) {
       return _encodeNumber(input);
     }

--- a/lib/src/types/type_registry.dart
+++ b/lib/src/types/type_registry.dart
@@ -231,8 +231,12 @@ extension TypeRegistryExt on TypeRegistry {
     Object? value, {
     required Type type,
     required Encoding encoding,
+    bool? isSqlNull = false,
   }) {
-    if (value == null) return null;
+    if (isSqlNull == true || isSqlNull == null && value == null) {
+      return null;
+    }
+
     switch (type) {
       case GenericType():
         return type.encode(EncodeInput(value: value, encoding: encoding));

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -636,6 +636,7 @@ class _PgResultStreamSubscription
                     e.value,
                     type: e.type,
                     encoding: connection.encoding,
+                    isSqlNull: e.isSqlNull,
                   ))
               .toList(),
           portalName: _portalName,

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -870,6 +870,25 @@ void main() {
         expectedDartType: 'DateTimeRange',
       );
     });
+
+    test('ambiguous nulls', () async {
+      final statement =
+          await conn.prepare(Sql.indexed('SELECT @1:json IS NULL'));
+
+      // By default, null values in Dart are mapped to null values in SQL.
+      expect(await statement.run([TypedValue<Object>(Type.json, null)]), [
+        [true]
+      ]);
+
+      // For JSON types with have their own distinct null representation, we
+      // can use that instead:
+      expect(
+          await statement
+              .run([TypedValue<Object>(Type.json, null, isSqlNull: false)]),
+          [
+            [false]
+          ]);
+    });
   });
 
   group('Text encoders', () {


### PR DESCRIPTION
This is the extension for https://github.com/isoos/postgresql-dart/pull/324 in the other direction.
When binding values to a statement, users can explicitly describe which null representation they need for types where that's otherwise ambiguous.