### PR TITLE
Fixed double/real + added timestamp, numeric, date & json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## 3.2.1
 
-- Added some conversions for queryMode: QueryMode.simple (not complete):
-  `timestampWithTimezone`, `timestampWithoutTimezone`, `date`, `interval`, `numeric`, `json`, `jsonb`
-
-- Fixed some conversions for queryMode: QueryMode.simple:
-  `real`, `double`
+- Added or fixed decoders support for `QueryMode.simple`:
+  `double`, `real`, `timestampWithTimezone`, `timestampWithoutTimezone`,
+  `date`, `numeric`, `json`, `jsonb` [#338](https://github.com/isoos/postgresql-dart/pull/338) by [pst9354](https://github.com/pst9354).
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.2.1
+
+- Added some conversions for queryMode: QueryMode.simple (not complete):
+  `timestampWithTimezone`, `timestampWithoutTimezone`, `date`, `interval`, `numeric`, `json`, `jsonb`
+
+- Fixed some conversions for queryMode: QueryMode.simple:
+  `real`, `double`
+
 ## 3.2.0
 
 - Support for `tsvector` and `tsquery` types.

--- a/lib/src/types/text_codec.dart
+++ b/lib/src/types/text_codec.dart
@@ -138,7 +138,8 @@ class PostgresTextEncoder {
         final timezoneMinuteOffset = value.timeZoneOffset.inMinutes % 60;
 
         var hourComponent = timezoneHourOffset.abs().toString().padLeft(2, '0');
-        final minuteComponent = timezoneMinuteOffset.abs().toString().padLeft(2, '0');
+        final minuteComponent =
+            timezoneMinuteOffset.abs().toString().padLeft(2, '0');
 
         if (timezoneHourOffset >= 0) {
           hourComponent = '+$hourComponent';
@@ -209,7 +210,8 @@ class PostgresTextEncoder {
 
     if (type == Map) {
       return '{${value.map((s) {
-        final escaped = json.encode(s).replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+        final escaped =
+            json.encode(s).replaceAll(r'\', r'\\').replaceAll('"', r'\"');
 
         return '"$escaped"';
       }).join(',')}}';
@@ -253,25 +255,19 @@ class PostgresTextDecoder {
 
       case TypeOid.timestampWithTimezone:
       case TypeOid.timestampWithoutTimezone:
-        final String strTimeStamp = '${utf8.decode(di.bytes)}Z';
-        return DateTime.parse(strTimeStamp);
-
-      case TypeOid.interval:
-        return utf8.decode(di.bytes);
+        return DateTime.parse(di.asText);
 
       case TypeOid.numeric:
-        return double.parse(di.asText);
+        return di.asText;
 
       case TypeOid.date:
-        final String strTimeStamp = '${utf8.decode(di.bytes)}T00:00:00Z';
-        final DateTime dt = DateTime.parse(strTimeStamp);
-        return dt;
+        return DateTime.parse(di.asText);
 
       case TypeOid.json:
       case TypeOid.jsonb:
-        final String strJSON = utf8.decode(di.bytes);
-        return jsonDecode(strJSON);
+        return jsonDecode(di.asText);
 
+      case TypeOid.interval:
       case TypeOid.byteArray:
       case TypeOid.uuid:
       case TypeOid.point:

--- a/lib/src/types/text_codec.dart
+++ b/lib/src/types/text_codec.dart
@@ -138,8 +138,7 @@ class PostgresTextEncoder {
         final timezoneMinuteOffset = value.timeZoneOffset.inMinutes % 60;
 
         var hourComponent = timezoneHourOffset.abs().toString().padLeft(2, '0');
-        final minuteComponent =
-            timezoneMinuteOffset.abs().toString().padLeft(2, '0');
+        final minuteComponent = timezoneMinuteOffset.abs().toString().padLeft(2, '0');
 
         if (timezoneHourOffset >= 0) {
           hourComponent = '+$hourComponent';
@@ -210,8 +209,7 @@ class PostgresTextEncoder {
 
     if (type == Map) {
       return '{${value.map((s) {
-        final escaped =
-            json.encode(s).replaceAll(r'\', r'\\').replaceAll('"', r'\"');
+        final escaped = json.encode(s).replaceAll(r'\', r'\\').replaceAll('"', r'\"');
 
         return '"$escaped"';
       }).join(',')}}';
@@ -240,7 +238,7 @@ class PostgresTextDecoder {
         return int.parse(di.asText);
       case TypeOid.real:
       case TypeOid.double:
-        return num.parse(di.asText);
+        return double.parse(di.asText);
       case TypeOid.boolean:
         // In text data format when using simple query protocol, "true" & "false"
         // are represented as `t` and `f`,  respectively.
@@ -255,12 +253,27 @@ class PostgresTextDecoder {
 
       case TypeOid.timestampWithTimezone:
       case TypeOid.timestampWithoutTimezone:
+        final String strTimeStamp = utf8.decode(di.bytes) + 'Z';
+        return DateTime.parse(strTimeStamp);
+
       case TypeOid.interval:
+        return utf8.decode(di.bytes);
+
       case TypeOid.numeric:
-      case TypeOid.byteArray:
+        return double.parse(di.asText);
+
       case TypeOid.date:
+        final String strTimeStamp = utf8.decode(di.bytes) + 'T00:00:00Z';
+        final DateTime dt = DateTime.parse(strTimeStamp);
+        return dt;
+
       case TypeOid.json:
       case TypeOid.jsonb:
+        final String strJSON = utf8.decode(di.bytes);
+        return (jsonDecode(strJSON));
+        break;
+
+      case TypeOid.byteArray:
       case TypeOid.uuid:
       case TypeOid.point:
       case TypeOid.booleanArray:

--- a/lib/src/types/text_codec.dart
+++ b/lib/src/types/text_codec.dart
@@ -253,7 +253,7 @@ class PostgresTextDecoder {
 
       case TypeOid.timestampWithTimezone:
       case TypeOid.timestampWithoutTimezone:
-        final String strTimeStamp = utf8.decode(di.bytes) + 'Z';
+        final String strTimeStamp = '${utf8.decode(di.bytes)}Z';
         return DateTime.parse(strTimeStamp);
 
       case TypeOid.interval:
@@ -263,15 +263,14 @@ class PostgresTextDecoder {
         return double.parse(di.asText);
 
       case TypeOid.date:
-        final String strTimeStamp = utf8.decode(di.bytes) + 'T00:00:00Z';
+        final String strTimeStamp = '${utf8.decode(di.bytes)}T00:00:00Z';
         final DateTime dt = DateTime.parse(strTimeStamp);
         return dt;
 
       case TypeOid.json:
       case TypeOid.jsonb:
         final String strJSON = utf8.decode(di.bytes);
-        return (jsonDecode(strJSON));
-        break;
+        return jsonDecode(strJSON);
 
       case TypeOid.byteArray:
       case TypeOid.uuid:

--- a/lib/src/types/text_codec.dart
+++ b/lib/src/types/text_codec.dart
@@ -255,13 +255,24 @@ class PostgresTextDecoder {
 
       case TypeOid.timestampWithTimezone:
       case TypeOid.timestampWithoutTimezone:
-        return DateTime.parse(di.asText);
+        final raw = DateTime.parse(di.asText);
+        return DateTime.utc(
+          raw.year,
+          raw.month,
+          raw.day,
+          raw.hour,
+          raw.minute,
+          raw.second,
+          raw.millisecond,
+          raw.microsecond,
+        );
 
       case TypeOid.numeric:
         return di.asText;
 
       case TypeOid.date:
-        return DateTime.parse(di.asText);
+        final raw = DateTime.parse(di.asText);
+        return DateTime.utc(raw.year, raw.month, raw.day);
 
       case TypeOid.json:
       case TypeOid.jsonb:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol and connection pooling.
-version: 3.2.0
+version: 3.2.1
 homepage: https://github.com/isoos/postgresql-dart
 topics:
   - sql

--- a/test/decode_test.dart
+++ b/test/decode_test.dart
@@ -29,7 +29,7 @@ void main() {
       final rs = await conn
           .execute("SELECT '1999-01-08 04:05:06'::TIMESTAMP WITHOUT TIME ZONE");
       final item = rs.single.single as DateTime;
-      expect(item.toIso8601String(), '1999-01-08T04:05:06.000');
+      expect(item.toIso8601String(), '1999-01-08T04:05:06.000Z');
     });
 
     test('interval', () async {
@@ -51,7 +51,7 @@ void main() {
     test('date', () async {
       final rs = await conn.execute("SELECT '1999-01-08'::DATE");
       final item = rs.single.single as DateTime;
-      expect(item.toIso8601String(), '1999-01-08T00:00:00.000');
+      expect(item.toIso8601String(), '1999-01-08T00:00:00.000Z');
     });
 
     test('json', () async {

--- a/test/docker.dart
+++ b/test/docker.dart
@@ -62,6 +62,7 @@ class PostgresServer {
   Future<Connection> newConnection({
     ReplicationMode replicationMode = ReplicationMode.none,
     SslMode? sslMode,
+    QueryMode? queryMode,
   }) async {
     return Connection.open(
       await endpoint(),
@@ -71,6 +72,7 @@ class PostgresServer {
         replicationMode: replicationMode,
         transformer: loggingTransformer('conn'),
         sslMode: sslMode,
+        queryMode: queryMode,
       ),
     );
   }


### PR DESCRIPTION
Attempt to add some missing comversions in PostgresTextDecoder.
Also corrected conversion for double & real.

Created after discussion about: [PostgresTextDecoder](https://github.com/isoos/postgresql-dart/issues/337)
 