### PR TITLE
Added support for binary pgoutput replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.2
+
+- Added support for binary `pgoutput` replication by [wolframm](https://github.com/Wolframm-Activities-OU).
+
 ## 3.2.1
 
 - Added or fixed decoders support for `QueryMode.simple`:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol and connection pooling.
-version: 3.2.1
+version: 3.2.2
 homepage: https://github.com/isoos/postgresql-dart
 topics:
   - sql

--- a/test/v3_logical_replication_test.dart
+++ b/test/v3_logical_replication_test.dart
@@ -36,6 +36,11 @@ void main() {
   // - Two PostgreSQL connections are needed for testing replication.
   //    - One for listening to streaming replications (this connection will be locked).
   //    - The other one to modify the database (e.g. insert, delete, update, truncate)
+  _testReplication(true);
+  _testReplication(false);
+}
+
+_testReplication(bool binary) {
   withPostgresServer('test logical replication with pgoutput for decoding',
       initSqls: replicationSchemaInit, (server) {
     // use this for listening to messages
@@ -117,7 +122,7 @@ void main() {
 
       // start replication process
       final statement = 'START_REPLICATION SLOT $slotName LOGICAL $xlogpos '
-          "(proto_version '1', publication_names '$publicationName')";
+          "(proto_version '1', publication_names '$publicationName', binary '$binary')";
 
       await replicationConn.execute(statement);
     });


### PR DESCRIPTION
I noticed that replication using `pgoutput` in binary mode is not implemented and results in decoding errors:

 `"START_REPLICATION SLOT some_slot LOGICAL some_lsn (proto_version '1', publication_names 'some_pub', binary 'true')"`

Therefore I made a few non-breaking changes to allow the use of `binary 'true'`.

Let me know what you think.