### PR TITLE
Customizable type registry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 ## 3.4.0
 
-- Updated `TypeRegistry`:
-  - (internal) `encode` and `decode` methods may be asynchronous
-  - (internal) using `EncodedValue` instead of `EncodeOutput`
-- `TypeCodec` interface (may become public) is used for encoding/decoding value by OIDs.
-- `TypeEncoderFn` type definition for generic Dart -> Postgres object encoders (where type is not specified as parameter).
-- `RuntimeParameters` (accessible through `TypeCodecContext`) to access server-provided parameter status values.
+- Allowing custom type codecs to be registered when creating the `TypeRegistry`.
+- `TypeCodec` interface is used for encoding/decoding value by OIDs.
+  Gets a reference to `TypeCodecContext` which contains `encoding` and runtime parameters.
+- `TypeEncoderFn` value converter for generic Dart -> Postgres object encoders (where type is not specified as parameter).
+- `RuntimeParameters` to access server-provided parameter status values.
 
 ## 3.3.0
 

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -21,6 +21,8 @@ export 'src/types/geo_types.dart';
 export 'src/types/range_types.dart';
 export 'src/types/text_search.dart'
     show TsVector, TsWord, TsWordPos, TsWeight, TsQuery;
+export 'src/types/type_codec.dart'
+    show RuntimeParameters, TypeCodec, TypeCodecContext, TypeEncoderFn;
 export 'src/types/type_registry.dart' show TypeRegistry;
 
 /// A description of a SQL query as interpreted by this package.

--- a/lib/src/types/type_registry.dart
+++ b/lib/src/types/type_registry.dart
@@ -247,7 +247,13 @@ class TypeRegistry {
   final _codecs = <int, TypeCodec>{};
   final _genericTypeEncoders = <TypeEncoderFn>[];
 
-  TypeRegistry() {
+  TypeRegistry({
+    /// Override or extend the built-in type codecs.
+    Map<int, TypeCodec>? typeCodecs,
+
+    /// Prepend the built-in type encoders with custom encoders.
+    Iterable<TypeEncoderFn>? typeEncoderFns,
+  }) {
     _bySubstitutionName.addAll(_builtInTypeNames);
     _codecs.addAll(_builtInCodecs);
     for (final type in _builtInTypes) {
@@ -255,7 +261,11 @@ class TypeRegistry {
         _byTypeOid[type.oid!] = type;
       }
     }
+    if (typeCodecs != null) {
+      _codecs.addAll(typeCodecs);
+    }
     _genericTypeEncoders.addAll([
+      ...?typeEncoderFns,
       _defaultGenericTypeEncoder,
     ]);
   }


### PR DESCRIPTION
The is the first public-facing change for #346, enabling the customizable type converters to be added to a connection through the `TypeRegistry`.