### PR TITLE
Flag in the close method to abort running queries

### DIFF
--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -209,7 +209,7 @@ abstract class SessionExecutor {
 
   /// Closes this session, cleaning up resources and forbiding further calls to
   /// [prepare] and [execute].
-  Future<void> close({bool interruptRunning = false});
+  Future<void> close({bool force = false});
 }
 
 abstract class Connection implements Session, SessionExecutor {

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -209,6 +209,8 @@ abstract class SessionExecutor {
 
   /// Closes this session, cleaning up resources and forbiding further calls to
   /// [prepare] and [execute].
+  /// If [force] is set to true, the session will be closed immediately, instead
+  /// of waiting for any pending queries to finish.
   Future<void> close({bool force = false});
 }
 

--- a/lib/postgres.dart
+++ b/lib/postgres.dart
@@ -209,7 +209,7 @@ abstract class SessionExecutor {
 
   /// Closes this session, cleaning up resources and forbiding further calls to
   /// [prepare] and [execute].
-  Future<void> close();
+  Future<void> close({bool interruptRunning = false});
 }
 
 abstract class Connection implements Session, SessionExecutor {

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -298,7 +298,7 @@ class _PoolConnection implements Connection {
 
   @override
   Future<void> close({bool force = false}) async {
-    // Don't forward the close call unless interrupting. The underlying connection should be re-used
+    // Don't forward the close call unless forcing. The underlying connection should be re-used
     // when another pool connection is requested.
 
     if (force) {

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -41,14 +41,14 @@ class PoolImplementation<L> implements Pool<L> {
   Future<void> get closed => _semaphore.done;
 
   @override
-  Future<void> close() async {
+  Future<void> close({bool interruptRunning = false}) async {
     await _semaphore.close();
 
     // Connections are closed when they are returned to the pool if it's closed.
     // We still need to close statements that are currently unused.
     for (final connection in [..._connections]) {
-      if (!connection._isInUse) {
-        await connection._dispose();
+      if (interruptRunning || !connection._isInUse) {
+        await connection._dispose(interruptRunning: interruptRunning);
       }
     }
   }
@@ -254,9 +254,9 @@ class _PoolConnection implements Connection {
     return false;
   }
 
-  Future<void> _dispose() async {
+  Future<void> _dispose({ bool interruptRunning = false}) async {
     _pool._connections.remove(this);
-    await _connection.close();
+    await _connection.close(interruptRunning: interruptRunning);
   }
 
   @override
@@ -277,9 +277,13 @@ class _PoolConnection implements Connection {
   }
 
   @override
-  Future<void> close() async {
-    // Don't forward the close call, the underlying connection should be re-used
+  Future<void> close({bool interruptRunning = false}) async {
+    // Don't forward the close call unless interrupting. The underlying connection should be re-used
     // when another pool connection is requested.
+
+    if (interruptRunning) {
+      await _connection.close(interruptRunning: interruptRunning);
+    }
   }
 
   @override

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -582,8 +582,8 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
   }
 
   @override
-  Future<void> close() async {
-    await _close(false, null);
+  Future<void> close({bool interruptRunning = false}) async {
+    await _close(interruptRunning, null);
   }
 
   Future<void> _close(bool interruptRunning, PgException? cause,

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -582,8 +582,8 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
   }
 
   @override
-  Future<void> close({bool interruptRunning = false}) async {
-    await _close(interruptRunning, null);
+  Future<void> close({bool force = false}) async {
+    await _close(force, null);
   }
 
   Future<void> _close(bool interruptRunning, PgException? cause,

--- a/test/pool_test.dart
+++ b/test/pool_test.dart
@@ -210,7 +210,7 @@ void main() {
     });
   });
 
-  group('force close', () {
+  group(skip: 'not implemented', 'force close', () {
     Future<Pool> openPool(PostgresServer server) async {
       final pool = Pool.withEndpoints(
         [await server.endpoint()],

--- a/test/v3_close_test.dart
+++ b/test/v3_close_test.dart
@@ -69,44 +69,59 @@ void main() {
       await conn2.execute(
           'select pg_terminate_backend($conn1PID) from pg_stat_activity;');
     });
+  });
 
-    group('force close', () {
-      Future<void> expectConn1ClosesForcefully() async {
-        await conn1
-            .close(force: true) //
-            // If close takes too long, the test will fail (force=true would not be working correctly)
-            // as it would be waiting for the query to finish
-            .timeout(Duration(seconds: 1));
-        expect(conn1.isOpen, isFalse);
-      }
+  group('force close', () {
+    Future<Connection> openConnection(PostgresServer server) async {
+      final conn = await Connection.open(await server.endpoint());
+      addTearDown(conn.close);
+      return conn;
+    }
 
-      Future<void> runLongQuery(Session session) {
-        return session.execute('select pg_sleep(10) from pg_stat_activity;');
-      }
+    Future<void> expectConn1ClosesForcefully(Connection conn) async {
+      await conn
+          .close(force: true) //
+          // If close takes too long, the test will fail (force=true would not be working correctly)
+          // as it would be waiting for the query to finish
+          .timeout(Duration(seconds: 1));
+      expect(conn.isOpen, isFalse);
+    }
 
-      test('connection session', () async {
+    Future<void> runLongQuery(Session session) {
+      return session.execute('select pg_sleep(10) from pg_stat_activity;');
+    }
+
+    withPostgresServer('connection session', (server) {
+      test('', () async {
+        final conn = await openConnection(server);
         // ignore: unawaited_futures
-        runLongQuery(conn1);
+        runLongQuery(conn);
         // let it start
         await Future.delayed(const Duration(milliseconds: 100));
-        await expectConn1ClosesForcefully();
+        await expectConn1ClosesForcefully(conn);
       });
+    });
 
-      test('tx session', () async {
+    withPostgresServer('tx session', (server) {
+      test('', () async {
+        final conn = await openConnection(server);
         // ignore: unawaited_futures
         // Ignore async error, it will fail when the connection is closed and it tries to do COMMIT
-        conn1.runTx(runLongQuery).ignore();
+        conn.runTx(runLongQuery).ignore();
         // let it start
         await Future.delayed(const Duration(milliseconds: 100));
-        await expectConn1ClosesForcefully();
+        await expectConn1ClosesForcefully(conn);
       });
+    });
 
-      test('run session', () async {
+    withPostgresServer('run session', (server) {
+      test('', () async {
+        final conn = await openConnection(server);
         // ignore: unawaited_futures
-        conn1.run(runLongQuery);
+        conn.run(runLongQuery);
         // let it start
         await Future.delayed(const Duration(milliseconds: 100));
-        await expectConn1ClosesForcefully();
+        await expectConn1ClosesForcefully(conn);
       });
     });
   });

--- a/test/v3_close_test.dart
+++ b/test/v3_close_test.dart
@@ -69,6 +69,46 @@ void main() {
       await conn2.execute(
           'select pg_terminate_backend($conn1PID) from pg_stat_activity;');
     });
+
+    group('force close', () {
+      Future<void> expectConn1ClosesForcefully() async {
+        await conn1
+            .close(force: true) //
+            // If close takes too long, the test will fail (force=true would not be working correctly)
+            // as it would be waiting for the query to finish
+            .timeout(Duration(seconds: 1));
+        expect(conn1.isOpen, isFalse);
+      }
+
+      Future<void> runLongQuery(Session session) {
+        return session.execute('select pg_sleep(10) from pg_stat_activity;');
+      }
+
+      test('connection session', () async {
+        // ignore: unawaited_futures
+        runLongQuery(conn1);
+        // let it start
+        await Future.delayed(const Duration(milliseconds: 100));
+        await expectConn1ClosesForcefully();
+      });
+
+      test('tx session', () async {
+        // ignore: unawaited_futures
+        // Ignore async error, it will fail when the connection is closed and it tries to do COMMIT
+        conn1.runTx(runLongQuery).ignore();
+        // let it start
+        await Future.delayed(const Duration(milliseconds: 100));
+        await expectConn1ClosesForcefully();
+      });
+
+      test('run session', () async {
+        // ignore: unawaited_futures
+        conn1.run(runLongQuery);
+        // let it start
+        await Future.delayed(const Duration(milliseconds: 100));
+        await expectConn1ClosesForcefully();
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Lets users implement use cases such as #394 

Other alternative boolean names for the flag:

force
abortRunningQueries
abortRunning
cancelRunningQueries
cancelRunning


