### PR TITLE
Don't ignore close in the pool when using force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.4.8
 
-- Fix: Don't ignore de pool resource `close` call when using foce.
+- Fix: Don't ignore de pool resource `close` call when using foce. [#406](https://github.com/isoos/postgresql-dart/pull/406) by [davidmartos96](https://github.com/davidmartos96).
 
 ## 3.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.8
+
+- Fix: Don't ignore de pool resource `close` call when using foce.
+
 ## 3.4.7
 
 - Implemented `Pool.close(force: true)` (using [davidmartos96](https://github.com/davidmartos96)'s [#397](https://github.com/isoos/postgresql-dart/pull/397) as baseline).

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -282,10 +282,12 @@ class _PoolConnection implements Connection {
 
   @override
   Future<void> close({bool force = false}) async {
-    // Don't forward the close call, the underlying connection should be re-used
+    // Don't forward the close call unless forcing. The underlying connection should be re-used
     // when another pool connection is requested.
 
-    // TODO: Implement force close.
+    if (force) {
+      await _connection.close(force: force);
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: postgres
 description: PostgreSQL database driver. Supports statement reuse and binary protocol and connection pooling.
-version: 3.4.7
+version: 3.4.8
 homepage: https://github.com/isoos/postgresql-dart
 topics:
   - sql


### PR DESCRIPTION
@isoos There was a pending TODO from my force close implementation in the pool. I believe it's necessary. Otherwise the close call is not actually sent, right?

The tests in https://github.com/davidmartos96/demo_postgres_shelf are failing without these changes. To catch this in the tests I think we would need to run an empty transaction call, an let it open for a long time, with a Future.delayed and then check that the Postgres server has cleaned up the connection from pg_stat_activity.

Related to that, is the current `force close` implementation suppose to stop running queries like `pg_cancel_backend` or `pg_terminate_backend` do? Or does it just close the socket? It looks like with the current implementation, `pg_sleep` from the tests is not stopped, rather, no one is listening to the result. Is that correct?  