### PR TITLE
Don't select closed/closing connections in the pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Don't reuse pool connections that are closed/closing.
+
 ## 3.5.3
 
 - New typed exceptions: `UniqueViolationException`, `ForeignKeyViolationException`. [#416](https://github.com/isoos/postgresql-dart/pull/416) by [hurrba](https://github.com/hurrba)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## Unreleased
-
-- Don't reuse pool connections that are closed/closing.
-
 ## 3.5.3
 
 - New typed exceptions: `UniqueViolationException`, `ForeignKeyViolationException`. [#416](https://github.com/isoos/postgresql-dart/pull/416) by [hurrba](https://github.com/hurrba)
+- Fix: don't reuse pool connections that are closed/closing. [#417](https://github.com/isoos/postgresql-dart/pull/417) by [davidmartos96](https://github.com/davidmartos96)
 
 ## 3.5.2
 

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -177,7 +177,7 @@ class PoolImplementation<L> implements Pool<L> {
   Future<_PoolConnection> _selectOrCreate(
       Endpoint endpoint, ResolvedConnectionSettings settings) async {
     final oldc =
-        _connections.firstWhereOrNull((c) => c._mayReuse(endpoint, settings) && c.isOpen);
+        _connections.firstWhereOrNull((c) => c._mayReuse(endpoint, settings));
     if (oldc != null) {
       // NOTE: It is important to update the _isInUse flag here, otherwise
       //       race conditions may create conflicts.
@@ -232,7 +232,7 @@ class _PoolConnection implements Connection {
       this._pool, this._endpoint, this._connectionSettings, this._connection);
 
   bool _mayReuse(Endpoint endpoint, ResolvedConnectionSettings settings) {
-    if (_isInUse || endpoint != _endpoint || _isExpired()) {
+    if (_isInUse || endpoint != _endpoint || _isExpired() || !isOpen) {
       return false;
     }
     if (!_connectionSettings.isMatchingConnection(settings)) {

--- a/lib/src/pool/pool_impl.dart
+++ b/lib/src/pool/pool_impl.dart
@@ -177,7 +177,7 @@ class PoolImplementation<L> implements Pool<L> {
   Future<_PoolConnection> _selectOrCreate(
       Endpoint endpoint, ResolvedConnectionSettings settings) async {
     final oldc =
-        _connections.firstWhereOrNull((c) => c._mayReuse(endpoint, settings));
+        _connections.firstWhereOrNull((c) => c._mayReuse(endpoint, settings) && c.isOpen);
     if (oldc != null) {
       // NOTE: It is important to update the _isInUse flag here, otherwise
       //       race conditions may create conflicts.


### PR DESCRIPTION
Recently, after updating to Dart 3.7 I started noticing the following error. I haven't been able to try lowering the Dart version, but I did try a possible patch in the library that makes it work. 
My understanding is that the pool is picking a connection that is closed or closing, so it will fail when trying to use it. I've tried deploying this fix in the server as it seemed low risk and I haven't seen the error since. 
Deployed postgres from pub again and they start showing up again.

![image](https://github.com/user-attachments/assets/2c553145-62d9-48cb-9351-673111ea524d)

![image](https://github.com/user-attachments/assets/ff6608cb-286c-46b5-a50d-02d7d4b4dca7)

![image](https://github.com/user-attachments/assets/5b48dcda-7ec4-4a22-b1a1-262c0e40cab4)
