### PR TITLE
Fix stale _transactionException after ROLLBACK TO SAVEPOINT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ doc/api/
 
 # VS Code IDE
 .vscode/
+
+# Reference libraries for bug research
+_reference/

--- a/lib/src/v3/connection.dart
+++ b/lib/src/v3/connection.dart
@@ -533,6 +533,13 @@ class PgConnectionImplementation extends _PgSessionBase implements Connection {
           _pending!.handleError(exception);
         }
       } else if (_pending != null) {
+        // If PostgreSQL reports the transaction is healthy (e.g. after a
+        // successful ROLLBACK TO SAVEPOINT), clear any stale exception so that
+        // mayCommit can return true and the outer runTx can COMMIT.
+        if (message is ReadyForQueryMessage &&
+            message.state == ReadyForQueryMessageState.transaction) {
+          _activeTransaction?._transactionException = null;
+        }
         await _pending!.handleMessage(message);
       }
     } finally {

--- a/test/transaction_test.dart
+++ b/test/transaction_test.dart
@@ -836,5 +836,30 @@ void main() {
         }
       },
     );
+
+    test(
+      'ROLLBACK TO SAVEPOINT clears _transactionException so subsequent work commits',
+      () async {
+        await conn.runTx((tx) async {
+          await tx.execute('SAVEPOINT sp1');
+
+          try {
+            // 42P01 – relation does not exist
+            await tx.execute('SELECT 1 FROM _nonexistent_xyz_ LIMIT 1');
+          } catch (_) {
+            await tx.execute('ROLLBACK TO SAVEPOINT sp1');
+            await tx.execute('RELEASE SAVEPOINT sp1');
+          }
+
+          // This insert must commit; before the fix it was silently rolled back.
+          await tx.execute('INSERT INTO t (id) VALUES (42)');
+        });
+
+        final rows = await conn.execute('SELECT id FROM t WHERE id = 42');
+        expect(rows, [
+          [42],
+        ], reason: 'Insert after savepoint recovery should have been committed');
+      },
+    );
   });
 }


### PR DESCRIPTION
Fixes #454

  ## Problem

  When any `PgException` occurred inside `runTx`, the internal `_transactionException` field was set and never
  cleared — even after a successful `ROLLBACK TO SAVEPOINT` restored PostgreSQL to a healthy state. `mayCommit`
  therefore returned `false` and the driver sent `ROLLBACK` instead of `COMMIT`, silently discarding all subsequent
  work that completed successfully at the PostgreSQL level.

  ## Root cause

  `_handleMessage` sets `_transactionException` on every `ErrorResponseMessage` (line 531) but has no path to clear
  it. After `ROLLBACK TO SAVEPOINT`, PostgreSQL sends `ReadyForQuery(state='T')` — the authoritative signal that the
  connection is in a clean, committable state — which the driver was ignoring for this purpose.

  ## Fix

  Clear `_transactionException` in `_handleMessage` when a `ReadyForQuery` with `state='T'` is received. This matches
  the approach taken by [asyncpg](https://github.com/MagicStack/asyncpg) and [pgx](https://github.com/jackc/pgx),
  both of which treat `ReadyForQuery('T')` as the signal that the connection is healthy.

  ## Testing

  Added a regression test in `test/transaction_test.dart` that:
  1. Triggers a `42P01` error inside `runTx`
  2. Recovers via `ROLLBACK TO SAVEPOINT` / `RELEASE SAVEPOINT`
  3. Inserts a row and expects it to be committed

  The test fails on the original code and passes with this fix.